### PR TITLE
[master] fix: Enable semantic release on master

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "webpack-dev-server": "^3.1.14"
   },
   "release": {
-    "branch": "next"
+    "branch": "master"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Short description of what this resolves:
A short fix to enable semantic release on the master branch instead of the next branch