### PR TITLE
Fix Button on Edge and prevent unwanted `click` events

### DIFF
--- a/packages/emd-basic-button/package.json
+++ b/packages/emd-basic-button/package.json
@@ -10,6 +10,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@stone-payments/emd-basic-icon": "^1.0.0",
     "@stone-payments/emd-basic-loader": "^1.0.0",
     "@stone-payments/emd-helpers": "^1.0.0",
     "@stone-payments/emd-hocs": "^1.0.1",

--- a/packages/emd-basic-button/public/index.css
+++ b/packages/emd-basic-button/public/index.css
@@ -33,7 +33,7 @@ h4, p {
 }
 
 emd-button {
-  width: min-content;
+  margin-right: auto;
 }
 
 emd-button:nth-of-type(7),

--- a/packages/emd-basic-button/public/index.css
+++ b/packages/emd-basic-button/public/index.css
@@ -94,3 +94,7 @@ emd-button:nth-of-type(n + 25) {
 emd-button:nth-of-type(n + 37) {
   color: #c3c8d2;
 }
+
+emd-button:nth-of-type(n + 43) {
+  color: #0db14b;
+}

--- a/packages/emd-basic-button/public/index.html
+++ b/packages/emd-basic-button/public/index.html
@@ -64,6 +64,32 @@
   <emd-button disabled>Button</emd-button>
   <emd-button disabled>Button</emd-button>
 
+  <h1>Button&thinsp;—&thinsp;With Icon</h1>
+  <emd-button>
+    <emd-icon icon="edit"></emd-icon>
+    Edit
+  </emd-button>
+  <emd-button href="#">
+    <emd-icon icon="edit"></emd-icon>
+    Edit
+  </emd-button>
+  <emd-button>
+    <emd-icon icon="edit"></emd-icon>
+    Edit
+  </emd-button>
+  <emd-button href="#">
+    <emd-icon icon="edit"></emd-icon>
+    Edit
+  </emd-button>
+  <emd-button>
+    <emd-icon icon="edit"></emd-icon>
+    Edit
+  </emd-button>
+  <emd-button href="#">
+    <emd-icon icon="edit"></emd-icon>
+    Edit
+  </emd-button>
+
   <h4>Missing hover, active and focus</h4>
 </body>
 </html>

--- a/packages/emd-basic-button/public/index.js
+++ b/packages/emd-basic-button/public/index.js
@@ -1,1 +1,2 @@
+import '@stone-payments/emd-basic-icon';
 import '../src/index.js';

--- a/packages/emd-basic-button/src/component/Button.css
+++ b/packages/emd-basic-button/src/component/Button.css
@@ -24,7 +24,10 @@
 
 .emd-button__button {
   -webkit-appearance: none;
-  display: block;
+  display: inline-flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  justify-content: center;
   width: 100%;
   height: 100%;
   box-sizing: border-box;
@@ -45,10 +48,6 @@
 }
 
 .emd-button__button_href {
-  display: flex;
-  flex-flow: row wrap;
-  align-items: center;
-  justify-content: center;
   text-decoration: none;
 }
 
@@ -96,8 +95,4 @@ emd-button {
 
 emd-button[disabled] {
   color: #c3c8d2;
-}
-
-emd-button > * {
-  pointer-events: none;
 }

--- a/packages/emd-basic-button/src/component/Button.css
+++ b/packages/emd-basic-button/src/component/Button.css
@@ -24,8 +24,8 @@
 
 .emd-button__button {
   -webkit-appearance: none;
-  display: inline-flex;
-  flex-flow: row nowrap;
+  display: flex;
+  flex-flow: row wrap;
   align-items: center;
   justify-content: center;
   width: 100%;

--- a/packages/emd-basic-button/src/component/ButtonController.js
+++ b/packages/emd-basic-button/src/component/ButtonController.js
@@ -3,6 +3,7 @@ export const ButtonController = (Base = class {}) =>
     constructor () {
       super();
       this.type = 'button';
+      this.handleClick = this.handleClick.bind(this);
     }
 
     static get properties () {
@@ -28,6 +29,22 @@ export const ButtonController = (Base = class {}) =>
           reflect: true
         }
       };
+    }
+
+    connectedCallback () {
+      super.connectedCallback();
+      this.addEventListener('click', this.handleClick);
+    }
+
+    disconnectedCallback () {
+      super.disconnectedCallback();
+      this.removeEventListener('click', this.handleClick);
+    }
+
+    handleClick (evt) {
+      if (this.disabled || this.loading) {
+        evt.stopPropagation();
+      }
     }
 
     render () {

--- a/packages/emd-basic-button/src/component/ButtonController.js
+++ b/packages/emd-basic-button/src/component/ButtonController.js
@@ -3,7 +3,7 @@ export const ButtonController = (Base = class {}) =>
     constructor () {
       super();
       this.type = 'button';
-      this.handleClick = this.handleClick.bind(this);
+      this._handleClick = this._handleClick.bind(this);
     }
 
     static get properties () {
@@ -33,15 +33,15 @@ export const ButtonController = (Base = class {}) =>
 
     connectedCallback () {
       super.connectedCallback();
-      this.addEventListener('click', this.handleClick);
+      this.addEventListener('click', this._handleClick);
     }
 
     disconnectedCallback () {
       super.disconnectedCallback();
-      this.removeEventListener('click', this.handleClick);
+      this.removeEventListener('click', this._handleClick);
     }
 
-    handleClick (evt) {
+    _handleClick (evt) {
       if (this.disabled || this.loading) {
         evt.stopPropagation();
       }


### PR DESCRIPTION
#### Short description of what this resolves:

- Fixes the bug that would prevent the Button to be clicked on IE Edge.
- Adds "Button With Icon" example.
- Prevents the `click` event from being dispatched while the Button is either disabled or loading.

#### To test:

```
npm install && npm test && npm start emd-basic-button
```
