### PR TITLE
Fix bug that causes Buttons to be unclickable on Edge

### DIFF
--- a/packages/emd-basic-button/src/component/Button.css
+++ b/packages/emd-basic-button/src/component/Button.css
@@ -12,10 +12,6 @@
   color: #c3c8d2;
 }
 
-::slotted(*) {
-  pointer-events: none;
-}
-
 .emd-button__wrapper {
   position: relative;
   width: 100%;


### PR DESCRIPTION
Fix bug that causes Buttons to be unclickable when shadow DOM polyfills are used.
