### PR TITLE
Make Card behave correctly when children are updated

### DIFF
--- a/packages/sling-web-component-card/src/component/Card.js
+++ b/packages/sling-web-component-card/src/component/Card.js
@@ -55,7 +55,10 @@ export class Card extends SlingElement {
       super.connectedCallback();
       const fn = this.childrenUpdated.bind(this);
       this._mo = new MutationObserver(fn);
-      this._mo.observe(this, { childList: true });
+      this._mo.observe(this, {
+        childList: true,
+        subtree: true,
+      });
       fn();
     }
   }
@@ -68,10 +71,11 @@ export class Card extends SlingElement {
   }
 
   childrenUpdated() {
-    this.visibleSlots = Array.from(this.children).map($el => $el.slot);
-    this.showheader = this.visibleSlots.includes('header');
-    this.showbody = this.visibleSlots.includes('');
-    this.showfooter = this.visibleSlots.includes('footer');
+    const visibleSlots = Array.from(this.children).map($el => $el.slot || '');
+
+    this.showheader = visibleSlots.includes('header');
+    this.showbody = visibleSlots.includes('');
+    this.showfooter = visibleSlots.includes('footer');
   }
 
   render() {

--- a/packages/sling-web-component-card/src/component/Card.test.js
+++ b/packages/sling-web-component-card/src/component/Card.test.js
@@ -41,6 +41,25 @@ describe('Card', () => {
     expect($card.nopaddingbody).to.be.false;
     expect($card.nopaddingfooter).to.be.false;
   });
+
+  describe('_childrenUpdated()', () => {
+    it('Should correctly behave to children being updated', (done) => {
+      $card.innerHTML = `
+        <h2 slot="header">Title</h2>
+        <div>Body</div>
+        <div slot="footer">Footer</div>
+      `;
+
+      $card.childrenUpdated();
+
+      setTimeout(() => {
+        expect($card.showheader).to.be.true;
+        expect($card.showbody).to.be.true;
+        expect($card.showfooter).to.be.true;
+        done();
+      }, 50);
+    });
+  });
 });
 
 describe('applySlotClass', () => {


### PR DESCRIPTION
#### Short description of what this resolves:

This PR fixes the legacy (Sling) Card so that when header, body or footer content is added, the Card displays the new information correctly.

##### To test

- Run:

```
npm install
npm start sling-web-component-card
```

- Inspect the first Card element on the page
- Right-click the element's tag and select `Edit HTML`
- Add a new `div` with any content in the Card element
- The new content should appear in the Card's body