### PR TITLE
Fix – legacy Sling Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* fix: substitute `.emd-table` CSS class for `.emd-table__wrapper` to avoid conflicts with the web components polyfill used by Edge
+
 <a name="2.3.0"></a>
 ## 2.3.0 (2019-08-01)
 

--- a/packages/sling-web-component-table/src/assets/Table.css
+++ b/packages/sling-web-component-table/src/assets/Table.css
@@ -1,4 +1,4 @@
-.emd-table {
+.emd-table__wrapper {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   border-collapse: collapse;
@@ -10,17 +10,17 @@
   background: var(--emd-table-background-color, transparent);
 }
 
-.emd-table.small {
+.emd-table__wrapper_size_small {
   font-size: 12px;
   line-height: 18px;
 }
 
-.emd-table.medium {
+.emd-table__wrapper_size_medium {
   font-size: 14px;
   line-height: 21px;
 }
 
-.emd-table.large {
+.emd-table__wrapper_size_large {
   font-size: 16px;
   line-height: 24px;
 }
@@ -52,15 +52,15 @@
   background: transparent;
 }
 
-.emd-table_row_success {
+.emd-table__row_success {
   border-left: 2px #31cd65;
 }
 
-.emd-table_clickablerows .emd-table__row {
+.emd-table__wrapper_clickablerows .emd-table__row {
   cursor: pointer;
 }
 
-.emd-table_clickablerows .emd-table__row:hover {
+.emd-table__wrapper_clickablerows .emd-table__row:hover {
   background: rgba(0, 0, 0, 0.02);
 }
 
@@ -97,17 +97,17 @@
   text-align: left;
 }
 
-.small .emd-table__symbol {
+.emd-table__wrapper_size_small .emd-table__symbol {
   font-size: 10px;
   line-height: 12px;
 }
 
-.medium .emd-table__symbol {
+.emd-table__wrapper_size_medium .emd-table__symbol {
   font-size: 11px;
   line-height: 13px;
 }
 
-.large .emd-table__symbol {
+.emd-table__wrapper_size_large .emd-table__symbol {
   font-size: 12px;
   line-height: 14px;
 }
@@ -136,12 +136,15 @@
 .bullet__status_1 {
   color: var(--calendar-status-1-color, #f9bf09);
 }
+
 .bullet__status_2 {
   color: var(--calendar-status-2-color, #B9C3CC);
 }
+
 .bullet__status_3 {
   color: var(--calendar-status-3-color, #c7352e);
 }
+
 .bullet__status_4 {
   color: var(--calendar-status-4-color, #31cd65);
 }

--- a/packages/sling-web-component-table/src/component/Table.js
+++ b/packages/sling-web-component-table/src/component/Table.js
@@ -278,13 +278,18 @@ export class Table extends HTMLElement {
       srccolumns: columns = [],
       noheader: noHeader,
       clickablerows: clickableRows,
+      size,
     } = this;
+
+    const wrapperClass = 'emd-table__wrapper' +
+      `${clickableRows ? ' emd-table__wrapper_clickablerows' : ''}` +
+      `${size ? ` emd-table__wrapper_size_${size}` : ''}`;
 
     this.shadowRoot.innerHTML = `
       <style>
         @import url('sling-web-component-table/src/index.css');
       </style>
-      <table class="emd-table${clickableRows ? ' emd-table_clickablerows' : ''} ${this.size ? this.size : ''}">
+      <table class="${wrapperClass}">
         <colgroup>
           ${columns.map(item => `<col style="width: ${item.width || 'auto'};"></col>`).join('')}
           ${this.editable ? '<col></col>' : ''}
@@ -309,7 +314,7 @@ export class Table extends HTMLElement {
         </thead>
         <tbody class="emd-table__body">
           ${dataSource.map((item, index) => `
-            <tr data-index="${index}" class="emd-table__row emd-table_row_success">
+            <tr data-index="${index}" class="emd-table__row emd-table__row_success">
               ${columns.map(header => `<td
                 class="emd-table__cell"
                 style="text-align: ${header.align || 'left'};">

--- a/packages/sling-web-component-table/src/component/Table.test.js
+++ b/packages/sling-web-component-table/src/component/Table.test.js
@@ -99,5 +99,11 @@ describe('Table', () => {
       done();
     });
   });
+
+  it('Should render the edit cell correctly', () => {
+    $table = document.createElement('sling-table');
+    expect($table.constructor.getEditCell().startsWith('table'))
+      .to.be.true;
+  });
 });
 


### PR DESCRIPTION
Substitute `.emd-table` CSS class for `.emd-table__wrapper` to avoid conflicts with the web components polyfill used by Edge.

To test:

```
npm install && npm start sling-web-component-table
```