### PR TITLE
Feature – Add noscroll property to Card

### DIFF
--- a/packages/emd-basic-card/src/component/Card.css
+++ b/packages/emd-basic-card/src/component/Card.css
@@ -56,6 +56,10 @@
   -webkit-overflow-scrolling: touch;
 }
 
+.emd-card__body.emd-card__area_noscroll {
+  overflow: hidden;
+}
+
 .emd-card__body.emd-card__area_hidden,
 .emd-card__body.emd-card__area_expanded {
   margin-top: 0;
@@ -75,6 +79,10 @@
   flex-flow: row wrap;
   flex-grow: 1;
   align-self: stretch;
+}
+
+.emd-card__area_noscroll .emd-card__slot_full {
+  height: 100%;
 }
 
 .emd-card__slot_left {

--- a/packages/emd-basic-card/src/component/Card.css
+++ b/packages/emd-basic-card/src/component/Card.css
@@ -82,7 +82,7 @@
 }
 
 .emd-card__area_noscroll .emd-card__slot_full {
-  height: 100%;
+  max-height: 100%;
 }
 
 .emd-card__slot_left {

--- a/packages/emd-basic-card/src/component/CardController.js
+++ b/packages/emd-basic-card/src/component/CardController.js
@@ -28,6 +28,14 @@ export const CardController = (Base = class {}) => class extends Base {
     this._updateView();
   }
 
+  get noscroll () {
+    return this.hasAttribute('noscroll');
+  }
+
+  set noscroll (value) {
+    setAttr(this, 'noscroll', value);
+  }
+
   get expandedbody () {
     return this.hasAttribute('expandedbody');
   }
@@ -37,7 +45,7 @@ export const CardController = (Base = class {}) => class extends Base {
   }
 
   static get observedAttributes () {
-    return ['expandedbody'];
+    return ['noscroll', 'expandedbody'];
   }
 
   attributeChangedCallback (...args) {

--- a/packages/emd-basic-card/src/component/CardView.js
+++ b/packages/emd-basic-card/src/component/CardView.js
@@ -4,7 +4,8 @@ export const CardView = ({
   showHeader,
   showBody,
   showFooter,
-  expandedbody
+  expandedbody,
+  noscroll
 }) => {
   let cardClasses = '';
   cardClasses += showHeader ? ' emd-card__wrapper_with_header' : '';
@@ -17,6 +18,7 @@ export const CardView = ({
   let cardBodyClasses = '';
   cardBodyClasses += !showBody ? ' emd-card__area_hidden' : '';
   cardBodyClasses += expandedbody ? ' emd-card__area_expanded' : '';
+  cardBodyClasses += noscroll ? ' emd-card__area_noscroll' : '';
 
   return html`
     <style>


### PR DESCRIPTION
This PR adds the `noscroll` property to the Card that forces it not to have a scrollbar.

I did this because I want the scrollbar to be State Wrapper's responsibility in some cases.

```html
<emd-card noscroll>
  <emd-state-wrapper><!-- responsible for scroll -->
    <emd-some-business></emd-some-business>
  <emd-state-wrapper>
</emd-card>
```

To test:
```
npm install
npm test
```