### PR TITLE
Task – State Wrapper improvements

### DIFF
--- a/packages/emd-basic-state-wrapper/package-lock.json
+++ b/packages/emd-basic-state-wrapper/package-lock.json
@@ -4,60 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@stone-payments/emd-basic-date": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-basic-date/-/emd-basic-date-1.0.0.tgz",
-			"integrity": "sha512-a7fgGgkCL5V4KFH31y01vx04o/QN4T354qranN1FpkKUNVo2kzzlKG1IkoxXV6eUbU2rFtadd+6mp9POpn3gXA==",
-			"requires": {
-				"@stone-payments/emd-formatters": "^1.0.0",
-				"@stone-payments/emd-helpers": "^1.0.0",
-				"@stone-payments/emd-hocs": "^1.0.1",
-				"@stone-payments/lit-element": "^2.2.1"
-			}
-		},
-		"@stone-payments/emd-basic-loader": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-basic-loader/-/emd-basic-loader-1.0.2.tgz",
-			"integrity": "sha512-dl6zHG3M6BaXnYHmFW80ZVEyT8mqbdHL5RhQeYwkdsEB8RXwgM3fMj7WXHmYVIrfgCjatVgShH4GJh+G8X9LgA==",
-			"requires": {
-				"@stone-payments/emd-helpers": "^1.0.0",
-				"@stone-payments/emd-hocs": "^1.0.1",
-				"@stone-payments/lit-element": "^2.2.1"
-			}
-		},
-		"@stone-payments/emd-basic-money": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-basic-money/-/emd-basic-money-1.0.0.tgz",
-			"integrity": "sha512-dXNA7SHlImiOqCkbMuDzBgkgBYKD+IBf04tXOQuKDYMc/jhdt8mLGRxTmZI449QtXQx4qHNBBtV34CUrrj4M+w==",
-			"requires": {
-				"@stone-payments/emd-formatters": "^1.0.0",
-				"@stone-payments/emd-helpers": "^1.0.0",
-				"@stone-payments/emd-hocs": "^1.0.1",
-				"@stone-payments/lit-html": "^1.1.0"
-			}
-		},
-		"@stone-payments/emd-business-weekly-calendar": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-business-weekly-calendar/-/emd-business-weekly-calendar-1.0.0.tgz",
-			"integrity": "sha512-N1GI2DG8YfqHFHoL8s87WaQoLoUhYfFX4IlCp05Gw0ydk+JRGhfXpRB4qzGo+HQknY//ELYpXgo8xJTE1YenGg==",
-			"requires": {
-				"@stone-payments/emd-basic-date": "^1.0.0",
-				"@stone-payments/emd-basic-loader": "^1.0.0",
-				"@stone-payments/emd-basic-money": "^1.0.0",
-				"@stone-payments/emd-helpers": "^1.0.0",
-				"@stone-payments/emd-hocs": "^1.0.1",
-				"@stone-payments/lit-element": "^2.2.1",
-				"date-fns": "^1.30.1"
-			}
-		},
-		"@stone-payments/emd-formatters": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-formatters/-/emd-formatters-1.0.0.tgz",
-			"integrity": "sha512-QNPgANhHxz44+cOQm8gOA8F0jU/kUnJXPhzYuWvI0dg8/rCnbNy62oQR6KhwoYcELm0NeED9RyIyKWtJbppJag==",
-			"requires": {
-				"date-fns": "^1.30.1"
-			}
-		},
 		"@stone-payments/emd-helpers": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stone-payments/emd-helpers/-/emd-helpers-1.0.0.tgz",

--- a/packages/emd-basic-state-wrapper/package-lock.json
+++ b/packages/emd-basic-state-wrapper/package-lock.json
@@ -5,147 +5,55 @@
 	"requires": true,
 	"dependencies": {
 		"@stone-payments/emd-basic-date": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-basic-date/-/emd-basic-date-0.1.3.tgz",
-			"integrity": "sha512-q8htimYYsYNJpHQPPmitDReqqCiu9FR+iT3zsjpUNQwFfioVNyrxARcUmEA76eJdCpaxVBMi63LiQp8UOFhF2Q==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-basic-date/-/emd-basic-date-1.0.0.tgz",
+			"integrity": "sha512-a7fgGgkCL5V4KFH31y01vx04o/QN4T354qranN1FpkKUNVo2kzzlKG1IkoxXV6eUbU2rFtadd+6mp9POpn3gXA==",
 			"requires": {
-				"@stone-payments/emd-formatters": "^0.1.2",
-				"@stone-payments/emd-helpers": "^0.1.4",
-				"@stone-payments/emd-hocs": "^0.1.2",
-				"@stone-payments/lit-element": "^2.1.0"
-			},
-			"dependencies": {
-				"@stone-payments/emd-helpers": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/@stone-payments/emd-helpers/-/emd-helpers-0.1.5.tgz",
-					"integrity": "sha512-CrC+b7r1c3LlpEj72OEvf0Lds8jL42KeZTyiWqkB8Ro1I5/MdjrTJhvAODig6jgty9WBqsHToalF1Cx1UKvOPA==",
-					"requires": {
-						"bluebird": "^3.5.3",
-						"change-case": "^3.1.0",
-						"date-fns": "^1.30.1",
-						"is-plain-object": "^2.0.4",
-						"timm": "^1.6.1"
-					}
-				},
-				"@stone-payments/emd-hocs": {
-					"version": "0.1.3",
-					"resolved": "https://registry.npmjs.org/@stone-payments/emd-hocs/-/emd-hocs-0.1.3.tgz",
-					"integrity": "sha512-4TA0Y2g/h9LtNlUrTYv4Ey+7+8QpqzU4e/V/OP9bZ/Rq1po6gpqB/TDNwl3O6NIeiUGVbzYtAe3s7p9RbPeMMw==",
-					"requires": {
-						"@stone-payments/emd-helpers": "^0.1.4",
-						"bluebird": "^3.5.3"
-					}
-				}
+				"@stone-payments/emd-formatters": "^1.0.0",
+				"@stone-payments/emd-helpers": "^1.0.0",
+				"@stone-payments/emd-hocs": "^1.0.1",
+				"@stone-payments/lit-element": "^2.2.1"
 			}
 		},
 		"@stone-payments/emd-basic-loader": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-basic-loader/-/emd-basic-loader-0.1.3.tgz",
-			"integrity": "sha512-EXw9Xe5ofq3bwKq1d1WOpqT9lSjTMzftTfP4pwNHMKnnq+R0CVQJ8cCrQrUNZD7my1EAaQH+Im7/rJz4AIpjzQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-basic-loader/-/emd-basic-loader-1.0.2.tgz",
+			"integrity": "sha512-dl6zHG3M6BaXnYHmFW80ZVEyT8mqbdHL5RhQeYwkdsEB8RXwgM3fMj7WXHmYVIrfgCjatVgShH4GJh+G8X9LgA==",
 			"requires": {
-				"@stone-payments/emd-helpers": "^0.1.4",
-				"@stone-payments/emd-hocs": "^0.1.2",
-				"@stone-payments/lit-element": "^2.1.0"
-			},
-			"dependencies": {
-				"@stone-payments/emd-helpers": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/@stone-payments/emd-helpers/-/emd-helpers-0.1.5.tgz",
-					"integrity": "sha512-CrC+b7r1c3LlpEj72OEvf0Lds8jL42KeZTyiWqkB8Ro1I5/MdjrTJhvAODig6jgty9WBqsHToalF1Cx1UKvOPA==",
-					"requires": {
-						"bluebird": "^3.5.3",
-						"change-case": "^3.1.0",
-						"date-fns": "^1.30.1",
-						"is-plain-object": "^2.0.4",
-						"timm": "^1.6.1"
-					}
-				},
-				"@stone-payments/emd-hocs": {
-					"version": "0.1.3",
-					"resolved": "https://registry.npmjs.org/@stone-payments/emd-hocs/-/emd-hocs-0.1.3.tgz",
-					"integrity": "sha512-4TA0Y2g/h9LtNlUrTYv4Ey+7+8QpqzU4e/V/OP9bZ/Rq1po6gpqB/TDNwl3O6NIeiUGVbzYtAe3s7p9RbPeMMw==",
-					"requires": {
-						"@stone-payments/emd-helpers": "^0.1.4",
-						"bluebird": "^3.5.3"
-					}
-				}
+				"@stone-payments/emd-helpers": "^1.0.0",
+				"@stone-payments/emd-hocs": "^1.0.1",
+				"@stone-payments/lit-element": "^2.2.1"
 			}
 		},
 		"@stone-payments/emd-basic-money": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-basic-money/-/emd-basic-money-0.1.3.tgz",
-			"integrity": "sha512-wa4xdrNqeP0ecsEtE9oJvFqWpKsRA5unF0t/skdeR6I8nicTUboevLs35tsH6n1QZ2EaXt5ZLHZ0lbUrp7WAwA==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-basic-money/-/emd-basic-money-1.0.0.tgz",
+			"integrity": "sha512-dXNA7SHlImiOqCkbMuDzBgkgBYKD+IBf04tXOQuKDYMc/jhdt8mLGRxTmZI449QtXQx4qHNBBtV34CUrrj4M+w==",
 			"requires": {
-				"@stone-payments/emd-formatters": "^0.1.2",
-				"@stone-payments/emd-helpers": "^0.1.4",
-				"@stone-payments/emd-hocs": "^0.1.2",
-				"@stone-payments/lit-html": "^1.0.0"
-			},
-			"dependencies": {
-				"@stone-payments/emd-helpers": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/@stone-payments/emd-helpers/-/emd-helpers-0.1.5.tgz",
-					"integrity": "sha512-CrC+b7r1c3LlpEj72OEvf0Lds8jL42KeZTyiWqkB8Ro1I5/MdjrTJhvAODig6jgty9WBqsHToalF1Cx1UKvOPA==",
-					"requires": {
-						"bluebird": "^3.5.3",
-						"change-case": "^3.1.0",
-						"date-fns": "^1.30.1",
-						"is-plain-object": "^2.0.4",
-						"timm": "^1.6.1"
-					}
-				},
-				"@stone-payments/emd-hocs": {
-					"version": "0.1.3",
-					"resolved": "https://registry.npmjs.org/@stone-payments/emd-hocs/-/emd-hocs-0.1.3.tgz",
-					"integrity": "sha512-4TA0Y2g/h9LtNlUrTYv4Ey+7+8QpqzU4e/V/OP9bZ/Rq1po6gpqB/TDNwl3O6NIeiUGVbzYtAe3s7p9RbPeMMw==",
-					"requires": {
-						"@stone-payments/emd-helpers": "^0.1.4",
-						"bluebird": "^3.5.3"
-					}
-				}
+				"@stone-payments/emd-formatters": "^1.0.0",
+				"@stone-payments/emd-helpers": "^1.0.0",
+				"@stone-payments/emd-hocs": "^1.0.1",
+				"@stone-payments/lit-html": "^1.1.0"
 			}
 		},
 		"@stone-payments/emd-business-weekly-calendar": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-business-weekly-calendar/-/emd-business-weekly-calendar-0.1.3.tgz",
-			"integrity": "sha512-jt+NzX0HJoafKQXqQ2YZJjvESMUYxDgAncsZxa6LAUPWrFOtYnDSoY5JGaqVlxYrb+NHJ6d1jLWW/ZvkydzwXQ==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-business-weekly-calendar/-/emd-business-weekly-calendar-1.0.0.tgz",
+			"integrity": "sha512-N1GI2DG8YfqHFHoL8s87WaQoLoUhYfFX4IlCp05Gw0ydk+JRGhfXpRB4qzGo+HQknY//ELYpXgo8xJTE1YenGg==",
 			"requires": {
-				"@stone-payments/emd-basic-date": "^0.1.3",
-				"@stone-payments/emd-basic-loader": "^0.1.3",
-				"@stone-payments/emd-basic-money": "^0.1.3",
-				"@stone-payments/emd-helpers": "^0.1.4",
-				"@stone-payments/emd-hocs": "^0.1.2",
-				"@stone-payments/lit-element": "^2.1.0",
+				"@stone-payments/emd-basic-date": "^1.0.0",
+				"@stone-payments/emd-basic-loader": "^1.0.0",
+				"@stone-payments/emd-basic-money": "^1.0.0",
+				"@stone-payments/emd-helpers": "^1.0.0",
+				"@stone-payments/emd-hocs": "^1.0.1",
+				"@stone-payments/lit-element": "^2.2.1",
 				"date-fns": "^1.30.1"
-			},
-			"dependencies": {
-				"@stone-payments/emd-helpers": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/@stone-payments/emd-helpers/-/emd-helpers-0.1.5.tgz",
-					"integrity": "sha512-CrC+b7r1c3LlpEj72OEvf0Lds8jL42KeZTyiWqkB8Ro1I5/MdjrTJhvAODig6jgty9WBqsHToalF1Cx1UKvOPA==",
-					"requires": {
-						"bluebird": "^3.5.3",
-						"change-case": "^3.1.0",
-						"date-fns": "^1.30.1",
-						"is-plain-object": "^2.0.4",
-						"timm": "^1.6.1"
-					}
-				},
-				"@stone-payments/emd-hocs": {
-					"version": "0.1.3",
-					"resolved": "https://registry.npmjs.org/@stone-payments/emd-hocs/-/emd-hocs-0.1.3.tgz",
-					"integrity": "sha512-4TA0Y2g/h9LtNlUrTYv4Ey+7+8QpqzU4e/V/OP9bZ/Rq1po6gpqB/TDNwl3O6NIeiUGVbzYtAe3s7p9RbPeMMw==",
-					"requires": {
-						"@stone-payments/emd-helpers": "^0.1.4",
-						"bluebird": "^3.5.3"
-					}
-				}
 			}
 		},
 		"@stone-payments/emd-formatters": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-formatters/-/emd-formatters-0.1.2.tgz",
-			"integrity": "sha512-+N1uOZzPwu8yL/vQ6hX2mAuGnksYAu1Thp1L/bZO2yYNKqQWSSJDRNSJWjeztmjLOtHa44e4BEXh4FsME4cYbw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-formatters/-/emd-formatters-1.0.0.tgz",
+			"integrity": "sha512-QNPgANhHxz44+cOQm8gOA8F0jU/kUnJXPhzYuWvI0dg8/rCnbNy62oQR6KhwoYcELm0NeED9RyIyKWtJbppJag==",
 			"requires": {
 				"date-fns": "^1.30.1"
 			}

--- a/packages/emd-basic-state-wrapper/package.json
+++ b/packages/emd-basic-state-wrapper/package.json
@@ -12,14 +12,13 @@
   "dependencies": {
     "@stone-payments/emd-basic-icon": "^1.0.0",
     "@stone-payments/emd-basic-loader": "^1.0.0",
-    "@stone-payments/emd-business-weekly-calendar": "^0.1.3",
+    "@stone-payments/emd-basic-table": "^1.0.0",
     "@stone-payments/emd-helpers": "^1.0.0",
     "@stone-payments/emd-hocs": "^1.0.1",
     "@stone-payments/lit-element": "^2.2.1"
   },
   "peerDependencies": {
     "chai": "^4.1.2",
-    "customer-js-sdk": "^1.26.0",
     "sinon": "^6.1.3",
     "sinon-chai": "^3.2.0"
   }

--- a/packages/emd-basic-state-wrapper/public/index.html
+++ b/packages/emd-basic-state-wrapper/public/index.html
@@ -20,10 +20,7 @@
       <span style="font-size: 12px;">off</span>
     </h1>
     <emd-state-wrapper>
-      <emd-weekly-calendar
-        affiliationcodes=""
-        startdate="">
-      </emd-weekly-calendar>
+      <emd-table></emd-table>
     </emd-state-wrapper>
   </div>
 
@@ -32,10 +29,7 @@
       State Wrapper&thinsp;—&thinsp;With scrollbar
     </h1>
     <emd-state-wrapper>
-      <emd-weekly-calendar
-        affiliationcodes=""
-        startdate="">
-      </emd-weekly-calendar>
+      <emd-table></emd-table>
     </emd-state-wrapper>
   </div>
 
@@ -44,10 +38,7 @@
       State Wrapper&thinsp;—&thinsp;Custom state
     </h1>
     <emd-state-wrapper>
-      <emd-weekly-calendar
-        affiliationcodes=""
-        startdate="">
-      </emd-weekly-calendar>
+      <emd-table></emd-table>
       <div slot="pristine">
         Não houve interação.
       </div>

--- a/packages/emd-basic-state-wrapper/public/index.html
+++ b/packages/emd-basic-state-wrapper/public/index.html
@@ -47,5 +47,12 @@
       </div>
     </emd-state-wrapper>
   </div>
+
+  <div>
+    <h1>
+      State Wrapper&thinsp;—&thinsp;Empty
+    </h1>
+    <emd-state-wrapper></emd-state-wrapper>
+  </div>
 </body>
 </html>

--- a/packages/emd-basic-state-wrapper/public/index.html
+++ b/packages/emd-basic-state-wrapper/public/index.html
@@ -50,6 +50,15 @@
 
   <div>
     <h1>
+      State Wrapper&thinsp;—&thinsp;Compact
+    </h1>
+    <emd-state-wrapper view="compact">
+      <emd-table></emd-table>
+    </emd-state-wrapper>
+  </div>
+
+  <div>
+    <h1>
       State Wrapper&thinsp;—&thinsp;Empty
     </h1>
     <emd-state-wrapper></emd-state-wrapper>

--- a/packages/emd-basic-state-wrapper/public/index.js
+++ b/packages/emd-basic-state-wrapper/public/index.js
@@ -1,13 +1,30 @@
-import { v0 as sdk } from 'customer-js-sdk';
+import { rows } from './rows.js';
+import '@stone-payments/emd-basic-table';
 import '../src/index.js';
-import '@stone-payments/emd-business-weekly-calendar';
-
-sdk.authorization.set(sdk.BEARER, ``);
 
 let currentButton = 'default';
 
 const wrappers = Array.from(document.querySelectorAll('emd-state-wrapper'));
-const businesses = Array.from(document.querySelectorAll('emd-weekly-calendar'));
+const tables = Array.from(document.querySelectorAll('emd-table'));
+
+const header = ['Bandeira', 'Valor Pago'];
+
+const appearance = {
+  align: ['left', 'right'],
+  valign: 'middle'
+};
+
+const adapter = ({ value, currency, brand, date }) => [
+  brand,
+  value
+];
+
+tables.forEach(table => {
+  table.rows = rows;
+  table.adapter = adapter;
+  table.appearance = appearance;
+  table.header = header;
+});
 
 const stateButtons = Array
   .from(document.querySelectorAll('button'))
@@ -41,56 +58,10 @@ stateButtons.forEach(button => {
       wrapper.currentState = currentButton;
     });
   };
+
+  wrappers.forEach(wrapper => {
+    wrapper.currentState = 'default';
+  });
 });
 
 updateStateButtons();
-
-businesses.forEach(business => {
-  business.source = [
-    {
-      date: '2019-01-31',
-      value: 48.96,
-      currency: 'BRL'
-    },
-    {
-      date: '2019-02-01',
-      value: 73.3,
-      currency: 'BRL'
-    },
-    {
-      date: '2019-02-04',
-      value: 0,
-      currency: 'BRL'
-    },
-    {
-      date: '2019-02-05',
-      value: 0,
-      currency: 'BRL'
-    },
-    {
-      date: '2019-02-06',
-      value: 265.01,
-      currency: 'BRL'
-    },
-    {
-      date: '2019-02-01',
-      value: 73.3,
-      currency: 'BRL'
-    },
-    {
-      date: '2019-02-04',
-      value: 0,
-      currency: 'BRL'
-    },
-    {
-      date: '2019-02-05',
-      value: 0,
-      currency: 'BRL'
-    },
-    {
-      date: '2019-02-06',
-      value: 265.01,
-      currency: 'BRL'
-    }
-  ];
-});

--- a/packages/emd-basic-state-wrapper/public/index.js
+++ b/packages/emd-basic-state-wrapper/public/index.js
@@ -7,16 +7,16 @@ let currentButton = 'default';
 const wrappers = Array.from(document.querySelectorAll('emd-state-wrapper'));
 const tables = Array.from(document.querySelectorAll('emd-table'));
 
-const header = ['Bandeira', 'Valor Pago'];
+const header = ['Movie', 'Year'];
 
 const appearance = {
   align: ['left', 'right'],
   valign: 'middle'
 };
 
-const adapter = ({ value, currency, brand, date }) => [
-  brand,
-  value
+const adapter = ({ name, year }) => [
+  name,
+  year
 ];
 
 tables.forEach(table => {
@@ -61,6 +61,7 @@ stateButtons.forEach(button => {
 
   wrappers.forEach(wrapper => {
     wrapper.currentState = 'default';
+    wrapper.recovery = () => window.alert('custom recovery method');
   });
 });
 

--- a/packages/emd-basic-state-wrapper/public/index.js
+++ b/packages/emd-basic-state-wrapper/public/index.js
@@ -61,7 +61,7 @@ stateButtons.forEach(button => {
 
   wrappers.forEach(wrapper => {
     wrapper.currentState = 'default';
-    wrapper.recovery = () => window.alert('custom recovery method');
+    wrapper.recovery = () => window.alert('Custom Recovery Method');
   });
 });
 

--- a/packages/emd-basic-state-wrapper/public/rows.js
+++ b/packages/emd-basic-state-wrapper/public/rows.js
@@ -1,0 +1,44 @@
+export const rows = [
+  {
+    date: '2019-03-30T12:25:57.6672005+00:00',
+    value: 7.5,
+    currency: 'BRL',
+    brand: 'elo'
+  },
+  {
+    date: '2019-03-30T12:25:57.5755048+00:00',
+    value: 420,
+    currency: 'BRL',
+    brand: 'mastercard'
+  },
+  {
+    date: '2019-03-30T12:25:57.3247419+00:00',
+    value: 40,
+    currency: 'BRL',
+    brand: 'mastercard'
+  },
+  {
+    date: '2019-03-30T12:25:57.2519149+00:00',
+    value: 803.25,
+    currency: 'BRL',
+    brand: 'mastercard'
+  },
+  {
+    date: '2019-03-30T12:25:56.5328065+00:00',
+    value: 82.8,
+    currency: 'BRL',
+    brand: 'mastercard'
+  },
+  {
+    date: '2019-03-30T12:25:57.5755048+00:00',
+    value: 420,
+    currency: 'BRL',
+    brand: 'mastercard'
+  },
+  {
+    date: '2019-03-30T12:25:57.6672005+00:00',
+    value: 7.5,
+    currency: 'BRL',
+    brand: 'elo'
+  }
+];

--- a/packages/emd-basic-state-wrapper/public/rows.js
+++ b/packages/emd-basic-state-wrapper/public/rows.js
@@ -1,44 +1,10 @@
 export const rows = [
-  {
-    date: '2019-03-30T12:25:57.6672005+00:00',
-    value: 7.5,
-    currency: 'BRL',
-    brand: 'elo'
-  },
-  {
-    date: '2019-03-30T12:25:57.5755048+00:00',
-    value: 420,
-    currency: 'BRL',
-    brand: 'mastercard'
-  },
-  {
-    date: '2019-03-30T12:25:57.3247419+00:00',
-    value: 40,
-    currency: 'BRL',
-    brand: 'mastercard'
-  },
-  {
-    date: '2019-03-30T12:25:57.2519149+00:00',
-    value: 803.25,
-    currency: 'BRL',
-    brand: 'mastercard'
-  },
-  {
-    date: '2019-03-30T12:25:56.5328065+00:00',
-    value: 82.8,
-    currency: 'BRL',
-    brand: 'mastercard'
-  },
-  {
-    date: '2019-03-30T12:25:57.5755048+00:00',
-    value: 420,
-    currency: 'BRL',
-    brand: 'mastercard'
-  },
-  {
-    date: '2019-03-30T12:25:57.6672005+00:00',
-    value: 7.5,
-    currency: 'BRL',
-    brand: 'elo'
-  }
+  { name: 'Avengers: Infinity War', year: 2018 },
+  { name: 'Black Panther', year: 2018 },
+  { name: 'Deadpool 2', year: 2018 },
+  { name: 'Ant-Man and the Wasp', year: 2018 },
+  { name: 'Jurassic World: Fallen Kingdom', year: 2018 },
+  { name: 'Fantastic Beasts: The Crimes of Grindelwald', year: 2018 },
+  { name: 'Solo: A Star Wars Story', year: 2018 },
+  { name: 'Bumblebee', year: 2018 }
 ];

--- a/packages/emd-basic-state-wrapper/src/component/StateWrapper.css
+++ b/packages/emd-basic-state-wrapper/src/component/StateWrapper.css
@@ -32,8 +32,9 @@
   transition: opacity 0.13s ease-in-out, width 0s 0.13s, height 0s 0.13s;
 }
 
-.emd-state-wrapper__state_current {
+.emd-state-wrapper__state_current .emd-state-wrapper__inner {
   overflow: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .emd-state-wrapper__state_current,

--- a/packages/emd-basic-state-wrapper/src/component/StateWrapper.css
+++ b/packages/emd-basic-state-wrapper/src/component/StateWrapper.css
@@ -66,6 +66,10 @@
   font-size: 0.625em;
 }
 
+.emd-state-wrapper__loader {
+  color: var(--emd-state-wrapper-loader-color, #0db14b);
+}
+
 .emd-state-wrapper__state_current {
   z-index: 2;
 }

--- a/packages/emd-basic-state-wrapper/src/component/StateWrapper.css
+++ b/packages/emd-basic-state-wrapper/src/component/StateWrapper.css
@@ -67,6 +67,10 @@
   z-index: 3;
 }
 
+.emd-state-wrapper__overlay_view_compact {
+  font-size: 0.625em;
+}
+
 .emd-state-wrapper__state_current {
   z-index: 2;
 }

--- a/packages/emd-basic-state-wrapper/src/component/StateWrapper.css
+++ b/packages/emd-basic-state-wrapper/src/component/StateWrapper.css
@@ -32,11 +32,6 @@
   transition: opacity 0.13s ease-in-out, width 0s 0.13s, height 0s 0.13s;
 }
 
-.emd-state-wrapper__state_current .emd-state-wrapper__inner {
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
 .emd-state-wrapper__state_current,
 .emd-state-wrapper__wrapper_loading .emd-state-wrapper__overlay {
   top: 0;
@@ -88,6 +83,11 @@
   position: relative;
   width: 100%;
   height: 100%;
+}
+
+.emd-state-wrapper__state_default .emd-state-wrapper__inner {
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .emd-state-wrapper__state_default:not(.emd-state-wrapper__state_current) {

--- a/packages/emd-basic-state-wrapper/src/component/StateWrapperController.js
+++ b/packages/emd-basic-state-wrapper/src/component/StateWrapperController.js
@@ -1,4 +1,4 @@
-import { isDeeplyEmpty } from '@stone-payments/emd-helpers';
+import { isDeeplyEmpty, isFunction } from '@stone-payments/emd-helpers';
 import { stateNames } from '../constants/stateNames.js';
 import { eventNames } from '../constants/eventNames.js';
 
@@ -27,6 +27,10 @@ export const StateWrapperController = (Base = class {}) =>
         },
         isLoading: {
           type: Boolean,
+          reflect: false
+        },
+        recovery: {
+          type: Function,
           reflect: false
         }
       };
@@ -67,7 +71,9 @@ export const StateWrapperController = (Base = class {}) =>
         [eventNames.SOURCE_CHANGE, this._handleSourceChange],
         [eventNames.REQUEST_ERROR, this._handleRequestError]
       ].forEach(([eventName, callback]) => {
-        this.wrapped[method](eventName, callback);
+        if (this.wrapped && isFunction(this.wrapped[method])) {
+          this.wrapped[method](eventName, callback);
+        }
       });
     }
 

--- a/packages/emd-basic-state-wrapper/src/component/StateWrapperController.js
+++ b/packages/emd-basic-state-wrapper/src/component/StateWrapperController.js
@@ -29,6 +29,10 @@ export const StateWrapperController = (Base = class {}) =>
           type: Boolean,
           reflect: false
         },
+        view: {
+          type: String,
+          reflect: true
+        },
         recovery: {
           type: Function,
           reflect: false

--- a/packages/emd-basic-state-wrapper/src/component/StateWrapperView.js
+++ b/packages/emd-basic-state-wrapper/src/component/StateWrapperView.js
@@ -1,7 +1,8 @@
 import { html } from '@stone-payments/lit-element';
+import { isFunction } from '@stone-payments/emd-helpers';
 import '@stone-payments/emd-basic-loader';
 import { stateNames } from '../constants/stateNames.js';
-import { isFunction } from '@stone-payments/emd-helpers/dist/cjs/es5/helpers/isFunction';
+import { getViewCssVariant } from './helpers/getViewCssVariant.js';
 
 const getStateClass = (state, currentState) => 'emd-state-wrapper__state' +
   ` emd-state-wrapper__state_${state.name}` +
@@ -10,7 +11,7 @@ const getStateClass = (state, currentState) => 'emd-state-wrapper__state' +
 const getWrapperClass = isLoading => 'emd-state-wrapper__wrapper' +
   (isLoading ? ' emd-state-wrapper__wrapper_loading' : '');
 
-const prepareView = (state, wrapped, recovery) => {
+const prepareView = (state, wrapped, recovery, view) => {
   const legacyRecovery = wrapped && isFunction(wrapped[state.action])
     ? wrapped[state.action].bind(wrapped)
     : undefined;
@@ -20,7 +21,7 @@ const prepareView = (state, wrapped, recovery) => {
     : undefined;
 
   return wrapped && state.view
-    ? state.view({ wrapped, action })
+    ? state.view({ wrapped, action, view })
     : '';
 };
 
@@ -29,13 +30,14 @@ export const StateWrapperView = ({
   isLoading,
   currentState,
   wrapped,
-  recovery
+  recovery,
+  view
 }) => html`
   <style>
     @import url("emd-basic-state-wrapper/src/component/StateWrapper.css")
   </style>
   <div class="${getWrapperClass(isLoading)}">
-    <div class="emd-state-wrapper__overlay">
+    <div class="${getViewCssVariant(view, 'overlay')}">
       <emd-loader loading></emd-loader>
     </div>
     ${states.map(state => html`
@@ -43,11 +45,11 @@ export const StateWrapperView = ({
         <div class="emd-state-wrapper__inner">
           ${state.name !== stateNames.DEFAULT ? html`
             <slot name="${state.name}">
-              ${prepareView(state, wrapped, recovery)}
+              ${prepareView(state, wrapped, recovery, view)}
             </slot>
           ` : html`
             <slot>
-              ${prepareView(state, wrapped, recovery)}
+              ${prepareView(state, wrapped, recovery, view)}
             </slot>
           `}
         </div>

--- a/packages/emd-basic-state-wrapper/src/component/StateWrapperView.js
+++ b/packages/emd-basic-state-wrapper/src/component/StateWrapperView.js
@@ -38,7 +38,7 @@ export const StateWrapperView = ({
   </style>
   <div class="${getWrapperClass(isLoading)}">
     <div class="${getViewCssVariant(view, 'overlay')}">
-      <emd-loader loading></emd-loader>
+      <emd-loader class="emd-state-wrapper__loader" loading></emd-loader>
     </div>
     ${states.map(state => html`
       <div class="${getStateClass(state, currentState)}">

--- a/packages/emd-basic-state-wrapper/src/component/helpers/getViewCssVariant.js
+++ b/packages/emd-basic-state-wrapper/src/component/helpers/getViewCssVariant.js
@@ -1,0 +1,5 @@
+export const getViewCssVariant = (view, element) => {
+  let cssClass = `emd-state-wrapper__${element}`;
+  cssClass += view ? ` emd-state-wrapper__${element}_view_${view}` : '';
+  return cssClass;
+};

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperEmpty.css
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperEmpty.css
@@ -4,5 +4,5 @@
 }
 
 .emd-state-wrapper__state_empty .emd-state-wrapper__text_view_compact {
-  font-size: 0.75em;
+  font-size: 0.875em;
 }

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperEmpty.css
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperEmpty.css
@@ -2,3 +2,7 @@
   font-size: 1em;
   text-align: center;
 }
+
+.emd-state-wrapper__state_empty .emd-state-wrapper__text_view_compact {
+  font-size: 0.75em;
+}

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperEmptyView.js
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperEmptyView.js
@@ -1,7 +1,8 @@
 import { html } from '@stone-payments/lit-element';
+import { getViewCssVariant } from '../helpers/getViewCssVariant.js';
 
-export const StateWrapperEmptyView = () => html`
-  <span class="emd-state-wrapper__text">
+export const StateWrapperEmptyView = ({ view }) => html`
+  <span class="${getViewCssVariant(view, 'text')}">
     Não há nada aqui.
   </span>
 `;

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperError.css
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperError.css
@@ -8,3 +8,12 @@
   font-size: 2em;
   margin-bottom: 0.4375em;
 }
+
+.emd-state-wrapper__state_error .emd-state-wrapper__icon_view_compact {
+  font-size: 1.25em;
+  margin-bottom: 0;
+}
+
+.emd-state-wrapper__state_error .emd-state-wrapper__text_view_compact {
+  display: none;
+}

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperError.css
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperError.css
@@ -1,7 +1,7 @@
 .emd-state-wrapper__state_error {
   font-size: 1em;
   text-align: center;
-  color: #e74c3c;
+  color: var(--emd-state-wrapper-error-color, #e74c3c);
 }
 
 .emd-state-wrapper__state_error .emd-state-wrapper__icon {

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperErrorView.js
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperErrorView.js
@@ -1,12 +1,13 @@
 import { html } from '@stone-payments/lit-element';
 import '@stone-payments/emd-basic-icon';
+import { getViewCssVariant } from '../helpers/getViewCssVariant.js';
 
-export const StateWrapperErrorView = () => html`
+export const StateWrapperErrorView = ({ view }) => html`
   <emd-icon
     icon="alert-circle"
-    class="emd-state-wrapper__icon">
+    class="${getViewCssVariant(view, 'icon')}">
   </emd-icon>  
-  <span class="emd-state-wrapper__text">
+  <span class="${getViewCssVariant(view, 'text')}">
     Erro permanente.
   </span>
 `;

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperPristine.css
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperPristine.css
@@ -2,3 +2,7 @@
   font-size: 1em;
   text-align: center;
 }
+
+.emd-state-wrapper__state_pristine .emd-state-wrapper__text_view_compact {
+  font-size: 0.75em;
+}

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperPristine.css
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperPristine.css
@@ -4,5 +4,5 @@
 }
 
 .emd-state-wrapper__state_pristine .emd-state-wrapper__text_view_compact {
-  font-size: 0.75em;
+  font-size: 0.875em;
 }

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperPristineView.js
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperPristineView.js
@@ -1,3 +1,1 @@
-import { html } from '@stone-payments/lit-element';
-
-export const StateWrapperPristineView = () => html``;
+export const StateWrapperPristineView = () => '';

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperRecovery.css
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperRecovery.css
@@ -4,7 +4,6 @@
   color: var(--emd-state-wrapper-recovery-color, #0db14b);
 }
 
-
 .emd-state-wrapper__state_recovery .emd-state-wrapper__action {
   display: flex;
   flex-flow: column nowrap;
@@ -16,4 +15,13 @@
 .emd-state-wrapper__state_recovery .emd-state-wrapper__icon {
   font-size: 2em;
   margin-bottom: 0.4375em;
+}
+
+.emd-state-wrapper__state_recovery .emd-state-wrapper__icon_view_compact {
+  font-size: 1.25em;
+  margin-bottom: 0;
+}
+
+.emd-state-wrapper__state_recovery .emd-state-wrapper__text_view_compact {
+  display: none;
 }

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperRecovery.css
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperRecovery.css
@@ -1,7 +1,7 @@
 .emd-state-wrapper__state_recovery {
   font-size: 1em;
   text-align: center;
-  color: #0db14b;
+  color: var(--emd-state-wrapper-recovery-color, #0db14b);
 }
 
 

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperRecoveryView.js
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperRecoveryView.js
@@ -12,19 +12,12 @@ const content = html`
   </span>
 `;
 
-export const StateWrapperRecoveryView = ({
-  wrapped,
-  action
-}) => {
-  const recoveryAction = wrapped[action];
-
-  return html`
-    ${recoveryAction ? html`
-      <div
-        @click="${recoveryAction.bind(wrapped)}"
-        class="emd-state-wrapper__action">
-        ${content}
-      </div>
-    ` : content}
-  `;
+export const StateWrapperRecoveryView = ({ action }) => {
+  return action ? html`
+    <div
+      @click="${action}"
+      class="emd-state-wrapper__action">
+      ${content}
+    </div>
+  ` : content;
 };

--- a/packages/emd-basic-state-wrapper/src/component/views/StateWrapperRecoveryView.js
+++ b/packages/emd-basic-state-wrapper/src/component/views/StateWrapperRecoveryView.js
@@ -1,23 +1,24 @@
 import { html } from '@stone-payments/lit-element';
 import '@stone-payments/emd-basic-icon';
+import { getViewCssVariant } from '../helpers/getViewCssVariant.js';
 
-const content = html`
+const StateWrapperContentView = ({ view }) => html`
   <emd-icon
     icon="refresh"
-    class="emd-state-wrapper__icon">
+    class="${getViewCssVariant(view, 'icon')}">
   </emd-icon>
-  <span class="emd-state-wrapper__text">
+  <span class="${getViewCssVariant(view, 'text')}">
     Falha no carregamento.<br/>
     Tentar novamente.
   </span>
 `;
 
-export const StateWrapperRecoveryView = ({ action }) => {
+export const StateWrapperRecoveryView = ({ action, view }) => {
   return action ? html`
     <div
       @click="${action}"
       class="emd-state-wrapper__action">
-      ${content}
+      ${StateWrapperContentView({ view })}
     </div>
-  ` : content;
+  ` : StateWrapperContentView({ view });
 };


### PR DESCRIPTION
This PR adds new features to the State Wrapper basic component that were long overdue, and yet, doesn't introduce any breaking changes:

- Add a compact `view` property that makes the component display smaller error messages;

  - Default:

    <img width="174" alt="Captura de Tela 2019-08-19 às 23 05 41" src="https://user-images.githubusercontent.com/125764/63312012-74360d00-c2d6-11e9-82b3-86e6a7326d0d.png">

  - Compact:

    <img width="60" alt="Captura de Tela 2019-08-19 às 23 05 46" src="https://user-images.githubusercontent.com/125764/63312022-78fac100-c2d6-11e9-9776-1189bbfb3f2b.png">

- Parameterize Error and Recovery text and icon colors;

  - Default (always red):

    <img width="160" alt="Captura de Tela 2019-08-19 às 23 07 32" src="https://user-images.githubusercontent.com/125764/63312036-857f1980-c2d6-11e9-9783-82fda503e00f.png">

  - Custom (any color):

    <img width="171" alt="Captura de Tela 2019-08-19 às 23 08 07" src="https://user-images.githubusercontent.com/125764/63312046-8fa11800-c2d6-11e9-82e6-12a856dc1120.png">

- Allow the `recovery` action to be passed as a parameter (before, it was always `buildSource`);

```html
<emd-state-wrapper>
  <emd-some-business></emd-some-business>
</emd-state-wrapper>
```

```js
const wrapper = document.querySelector('emd-state-wrapper');
const business = document.querySelector('emd-some-business');
wrapper.recovery = business.buildInput.bind(business);
```

- Make sure that the component won't break if empty;

```html
<emd-state-wrapper></emd-state-wrapper> <!-- this would break before -->
```

To run:

```
npm install
npm start emd-basic-state-wrapper
```