### PR TITLE
Feature – Allow recovery to be passed as a String

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,8 +6,8 @@
     "plugin:import/warnings"
   ],
   "env": {
-    "node": true,
-    "browser": true
+    "browser": true,
+    "node": true
   },
   "rules": {
     "max-len": ["error", {

--- a/packages/emd-basic-state-wrapper/src/component/StateWrapperView.js
+++ b/packages/emd-basic-state-wrapper/src/component/StateWrapperView.js
@@ -4,6 +4,8 @@ import '@stone-payments/emd-basic-loader';
 import { stateNames } from '../constants/stateNames.js';
 import { getViewCssVariant } from './helpers/getViewCssVariant.js';
 
+const { DEFAULT, RECOVERY } = stateNames;
+
 const getStateClass = (state, currentState) => 'emd-state-wrapper__state' +
   ` emd-state-wrapper__state_${state.name}` +
   (currentState === state.name ? ' emd-state-wrapper__state_current' : '');
@@ -26,7 +28,7 @@ export const prepareView = (state, wrapped, recovery, view) => {
 
   const legacyRecovery = stringToMethod(wrapped, state.action);
 
-  const action = (state.name === stateNames.RECOVERY)
+  const action = (state.name === RECOVERY)
     ? parsedRecovery || legacyRecovery
     : undefined;
 
@@ -53,7 +55,7 @@ export const StateWrapperView = ({
     ${states.map(state => html`
       <div class="${getStateClass(state, currentState)}">
         <div class="emd-state-wrapper__inner">
-          ${state.name !== stateNames.DEFAULT ? html`
+          ${state.name !== DEFAULT ? html`
             <slot name="${state.name}">
               ${prepareView(state, wrapped, recovery, view)}
             </slot>


### PR DESCRIPTION
This PR allows the `recovery` property to be passed as a String.

If it is a Function, it will be executed in recovery mode (like when a request fails).

If it is a String, a method with the same name will be exectuded for recovery.

If nothing is passed, the recovery method defaults to `buildSource` (the original behaviour).

New tests were added:
```
npm install
npm test
```