### PR TITLE
feat/barcode-field-type

### DIFF
--- a/packages/emd-basic-field/package-lock.json
+++ b/packages/emd-basic-field/package-lock.json
@@ -4,10 +4,39 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@stone-payments/emd-assets": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-assets/-/emd-assets-1.2.0.tgz",
+			"integrity": "sha512-LP8jo5vbbshm1MiNaKamf9vrET00pXbW8V6lb3VsM98qnsnE7vNo/S/pyVKGOLV96ftNnjV9Jk2MqdqjcE4SFg==",
+			"requires": {
+				"@stone-payments/emd-helpers": "^1.1.1"
+			}
+		},
+		"@stone-payments/emd-basic-icon": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-basic-icon/-/emd-basic-icon-1.1.0.tgz",
+			"integrity": "sha512-EHS/4sU5RZXqZUMV7QVpfxk/z+wcipMdJsK0OCVtv8DOzKEYNd7Aim1/OCtOA0DAkIzCzwxlhXHW6Ux7S8ipsw==",
+			"requires": {
+				"@stone-payments/emd-assets": "^1.2.0",
+				"@stone-payments/emd-helpers": "^1.1.2",
+				"@stone-payments/emd-hocs": "^1.1.0",
+				"@stone-payments/lit-element": "^2.2.1"
+			}
+		},
+		"@stone-payments/emd-basic-loader": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-basic-loader/-/emd-basic-loader-1.0.3.tgz",
+			"integrity": "sha512-PytC391G+WCnxutGQnEYHGFay+o2aPz1aUNG8RLnf+4tzgfwRFjo5/0TpFDYPXDPHw7Enk3YBXE9Xy58bAhgrw==",
+			"requires": {
+				"@stone-payments/emd-helpers": "^1.1.2",
+				"@stone-payments/emd-hocs": "^1.1.0",
+				"@stone-payments/lit-element": "^2.2.1"
+			}
+		},
 		"@stone-payments/emd-helpers": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-helpers/-/emd-helpers-1.1.2.tgz",
-			"integrity": "sha512-9QKsz+LT5M0AbfGSVGaFuSpA4oJG+8dkVxkNH/aINwrg1h4fDJ9eBlCJZvMkdpi6mCWo7TlB5bKy9FjJVR0LoA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-helpers/-/emd-helpers-1.3.0.tgz",
+			"integrity": "sha512-MXgR37jtbOaqDUJonBO4AOEcexIUXZJSOsEmAFQBGnyANlZ+KPOX1neeX53AVmAZxcWe4PHUczJshG4ELr8Oww==",
 			"requires": {
 				"bluebird": "^3.5.3",
 				"change-case": "^3.1.0",
@@ -23,6 +52,25 @@
 			"requires": {
 				"@stone-payments/emd-helpers": "^1.1.1",
 				"faker": "^4.1.0"
+			}
+		},
+		"@stone-payments/lit-element": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@stone-payments/lit-element/-/lit-element-2.2.2.tgz",
+			"integrity": "sha512-qVNVHFXr/HNgXOq3iTReZBKiKTQZPrJI58R7x95qucfGakSm4TcDFvXGVL7c7PgGN/QMq/yTjJk+KU9mYr1pVQ==",
+			"requires": {
+				"@stone-payments/lit-html": "1.1.1",
+				"lit-element": "2.2.0"
+			},
+			"dependencies": {
+				"@stone-payments/lit-html": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@stone-payments/lit-html/-/lit-html-1.1.1.tgz",
+					"integrity": "sha512-7z5pEUJAjXEWiSpg6Ki6XNJPN2oXh7/noj/8mDSD5QL+vglI3PBE04Jg+zyprrDC8W54coCk+ZCdtagIkBvQkA==",
+					"requires": {
+						"lit-html": "1.1.0"
+					}
+				}
 			}
 		},
 		"@stone-payments/lit-html": {
@@ -141,6 +189,14 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+		},
+		"lit-element": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.2.0.tgz",
+			"integrity": "sha512-Mzs3H7IO4wAnpzqreHw6dQqp9IG+h/oN8X9pgNbMZbE7x6B0aNOwP5Nveox/5HE+65ZfW2PeULEjoHkrwpTnuQ==",
+			"requires": {
+				"lit-html": "^1.0.0"
+			}
 		},
 		"lit-html": {
 			"version": "1.1.0",

--- a/packages/emd-basic-field/package.json
+++ b/packages/emd-basic-field/package.json
@@ -10,9 +10,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@stone-payments/emd-basic-icon": "^1.0.0",
-    "@stone-payments/emd-basic-loader": "^1.0.0",
-    "@stone-payments/emd-helpers": "^1.1.2",
+    "@stone-payments/emd-basic-icon": "^1.1.0",
+    "@stone-payments/emd-basic-loader": "^1.0.3",
+    "@stone-payments/emd-helpers": "^1.3.0",
     "@stone-payments/emd-hocs": "^1.1.0",
     "@stone-payments/lit-html": "^1.1.0",
     "cleave.js": "^1.4.7",

--- a/packages/emd-basic-field/public/index.html
+++ b/packages/emd-basic-field/public/index.html
@@ -44,6 +44,8 @@
   <emd-field type="cpf" placeholder="CPF"></emd-field>
   <emd-field type="tel" placeholder="Telephone"></emd-field>
   <emd-field type="money" placeholder="Money"></emd-field>
+  <emd-field type="barcode" placeholder="Billet barcode"></emd-field>
+  <emd-field type="conveniobarcode" placeholder="Convenio barcode"></emd-field>
 
   <h1>Field&thinsp;—&thinsp;Padding</h1>
   <emd-field value="Daft Punk" validationstatus="success"></emd-field>

--- a/packages/emd-basic-field/src/core.js
+++ b/packages/emd-basic-field/src/core.js
@@ -19,6 +19,9 @@ import { maskCnpj } from './types/cnpj/maskCnpj.js';
 import { validateCep } from './types/cep/validateCep.js';
 import { maskCep } from './types/cep/maskCep.js';
 
+import { validateBarcode } from './types/barcode/validateBarcode.js';
+import { maskBarcode, convenioMaskBarcode } from './types/barcode/maskBarcode.js';
+
 import { maskMoney } from './types/money/maskMoney.js';
 
 const withComponentAndFields = compose(
@@ -27,6 +30,8 @@ const withComponentAndFields = compose(
   withFieldType('cpf', validateCpf, maskCpf),
   withFieldType('cnpj', validateCnpj, maskCnpj),
   withFieldType('cep', validateCep, maskCep),
+  withFieldType('barcode', validateBarcode, maskBarcode),
+  withFieldType('conveniobarcode', validateBarcode, convenioMaskBarcode),
   withFieldType('money', undefined, maskMoney),
   withField,
   withComponent

--- a/packages/emd-basic-field/src/types/barcode/maskBarcode.js
+++ b/packages/emd-basic-field/src/types/barcode/maskBarcode.js
@@ -1,0 +1,13 @@
+import { maskMaker } from '../../helpers/maskMaker.js';
+
+export const maskBarcode = maskMaker({
+  numericOnly: true,
+  delimiters: ['-', ' ', '-', ' ', '-', ' ', '-', ' '],
+  blocks: [11, 1, 11, 1, 11, 1, 11, 1]
+});
+
+export const convenioMaskBarcode = maskMaker({
+  numericOnly: true,
+  delimiters: ['.', ' ', '.', ' ', '.', ' '],
+  blocks: [5, 5, 5, 6, 5, 6, 1, 14]
+});

--- a/packages/emd-basic-field/src/types/barcode/validateBarcode.js
+++ b/packages/emd-basic-field/src/types/barcode/validateBarcode.js
@@ -1,0 +1,5 @@
+import { isValidBarcode } from '@stone-payments/emd-helpers';
+
+export const validateBarcode = value => (value && !isValidBarcode(value)
+  ? 'Deve ser um código de barras válido'
+  : undefined);

--- a/packages/emd-basic-field/src/types/barcode/validateBarcode.spec.js
+++ b/packages/emd-basic-field/src/types/barcode/validateBarcode.spec.js
@@ -1,0 +1,6 @@
+import { expect } from 'chai';
+import { validateBarcode } from './validateBarcode.js';
+
+describe('validateBarcode', () => {
+
+});

--- a/packages/emd-basic-field/src/types/barcode/validateBarcode.spec.js
+++ b/packages/emd-basic-field/src/types/barcode/validateBarcode.spec.js
@@ -2,5 +2,35 @@ import { expect } from 'chai';
 import { validateBarcode } from './validateBarcode.js';
 
 describe('validateBarcode', () => {
+  it('Should return undefined when receiving no arguments', () => {
+    expect(validateBarcode()).to.be.undefined;
+  });
 
+  it('Should return undefined when receiving empty string', () => {
+    expect(validateBarcode('')).to.be.undefined;
+  });
+
+  it('Should return message when receiving invalid value', () => {
+    const barcode = {
+      caseOne: 'XXX9999999-X 99999999999-9 99999999999-C 99999999999-A',
+      caseTwo: 'ABC45678d12398-391203821397083921372173-832932',
+      caseThree: '///&**(*$(#$#&ˆ$ˆ&%@@#ˆ$#@%'
+    };
+
+    expect(validateBarcode(barcode.caseOne)).to.be.a('string');
+    expect(validateBarcode(barcode.caseTwo)).to.be.a('string');
+    expect(validateBarcode(barcode.caseThree)).to.be.a('string');
+  });
+
+  it('Should return undefined when receiving a valid string', () => {
+    const barcode = {
+      billet: '99999999999-9 99999999999-9 99999999999-9 99999999999-9',
+      convenio: '85555.55555 55555.555555 55555.555555 5 55555555555555',
+      outher: '59999999999-9 99999999999-9 99999999999-9 99999999999-9'
+    };
+
+    expect(validateBarcode(barcode.billet)).to.be.undefined;
+    expect(validateBarcode(barcode.convenio)).to.be.undefined;
+    expect(validateBarcode(barcode.outher)).to.be.undefined;
+  });
 });


### PR DESCRIPTION
This PR implements a `barcode` and `conveniobarcode` types:

`barcode`
![image](https://user-images.githubusercontent.com/4579340/65467151-26617700-de37-11e9-8535-703fd62b013f.png)

`conveniobarcode`
![image](https://user-images.githubusercontent.com/4579340/65467191-41cc8200-de37-11e9-8ace-563bd4a73b45.png)

New unit tests were added:
```
npm install
npm test
````

To run the component:
````
npm install
npm start emd-basic-field
```


