### PR TITLE
Feature – iMask and Billet field type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9981,7 +9981,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10396,7 +10397,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10452,6 +10454,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10495,12 +10498,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/emd-basic-field/package-lock.json
+++ b/packages/emd-basic-field/package-lock.json
@@ -72,11 +72,6 @@
 				"upper-case-first": "^1.1.0"
 			}
 		},
-		"cleave.js": {
-			"version": "1.4.10",
-			"resolved": "https://registry.npmjs.org/cleave.js/-/cleave.js-1.4.10.tgz",
-			"integrity": "sha512-7AWnh+6pgQbbRT+e7WnK/yc+U50zhtQZklvEcKDiFDpfcu3kb300BdV7FMYtGOIsAzD5TKy7KH38ZwgyWyFE2Q=="
-		},
 		"constant-case": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
@@ -112,6 +107,11 @@
 				"no-case": "^2.2.0",
 				"upper-case": "^1.1.3"
 			}
+		},
+		"imask": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/imask/-/imask-5.2.1.tgz",
+			"integrity": "sha512-MiYUC6zP3sHldoXovnbpYc9UXjL8t4GuiZGGgillFljzJaN/osq8AeCuS1DUwzwRydMLi8F9ZK3xHkOrXjuNcw=="
 		},
 		"is-lower-case": {
 			"version": "1.1.3",

--- a/packages/emd-basic-field/package-lock.json
+++ b/packages/emd-basic-field/package-lock.json
@@ -4,10 +4,29 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@stone-payments/emd-assets": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-assets/-/emd-assets-1.3.0.tgz",
+			"integrity": "sha512-u4EiABG6SrusHCYTFi1KPActdxdBf/v8nbbmR3IFUeJcy/5RO0rzvErafuJG9i+c0fIVNxkR7FZeQhFBH22JgQ==",
+			"requires": {
+				"@stone-payments/emd-helpers": "^1.1.1"
+			}
+		},
+		"@stone-payments/emd-basic-icon": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-basic-icon/-/emd-basic-icon-1.2.0.tgz",
+			"integrity": "sha512-cuee+DSCfNAnRELeeTpi1XKZ3IZA+/xnzIfsAxvPwB+jYpDOBjcysHCa+l4+NCzHIg0xf15MIjG7H8+FxQaTxQ==",
+			"requires": {
+				"@stone-payments/emd-assets": "^1.3.0",
+				"@stone-payments/emd-helpers": "^1.1.2",
+				"@stone-payments/emd-hocs": "^1.1.0",
+				"@stone-payments/lit-element": "^2.2.1"
+			}
+		},
 		"@stone-payments/emd-helpers": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-helpers/-/emd-helpers-1.1.2.tgz",
-			"integrity": "sha512-9QKsz+LT5M0AbfGSVGaFuSpA4oJG+8dkVxkNH/aINwrg1h4fDJ9eBlCJZvMkdpi6mCWo7TlB5bKy9FjJVR0LoA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-helpers/-/emd-helpers-1.3.0.tgz",
+			"integrity": "sha512-MXgR37jtbOaqDUJonBO4AOEcexIUXZJSOsEmAFQBGnyANlZ+KPOX1neeX53AVmAZxcWe4PHUczJshG4ELr8Oww==",
 			"requires": {
 				"bluebird": "^3.5.3",
 				"change-case": "^3.1.0",
@@ -17,12 +36,30 @@
 			}
 		},
 		"@stone-payments/emd-hocs": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-hocs/-/emd-hocs-1.1.0.tgz",
-			"integrity": "sha512-jezBimz6aLbRjk2HsNn1dRjfJlaQBOrfwPP2i0iNiYQrWDFLMxttdjh/sOPnUXxO7xE4ULN96H0IdmD4SnApYw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-hocs/-/emd-hocs-1.3.0.tgz",
+			"integrity": "sha512-DfkDs4dE6GIFkoPeWLktioZ2bBN9Qn2DLhSu6IafRfCdqFL0faPjz4shJ4QrwJnOX1EcvZqKS2J/vGfPFHpzTQ==",
 			"requires": {
-				"@stone-payments/emd-helpers": "^1.1.1",
-				"faker": "^4.1.0"
+				"@stone-payments/emd-helpers": "^1.1.1"
+			}
+		},
+		"@stone-payments/lit-element": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@stone-payments/lit-element/-/lit-element-2.2.2.tgz",
+			"integrity": "sha512-qVNVHFXr/HNgXOq3iTReZBKiKTQZPrJI58R7x95qucfGakSm4TcDFvXGVL7c7PgGN/QMq/yTjJk+KU9mYr1pVQ==",
+			"requires": {
+				"@stone-payments/lit-html": "1.1.1",
+				"lit-element": "2.2.0"
+			},
+			"dependencies": {
+				"@stone-payments/lit-html": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@stone-payments/lit-html/-/lit-html-1.1.1.tgz",
+					"integrity": "sha512-7z5pEUJAjXEWiSpg6Ki6XNJPN2oXh7/noj/8mDSD5QL+vglI3PBE04Jg+zyprrDC8W54coCk+ZCdtagIkBvQkA==",
+					"requires": {
+						"lit-html": "1.1.0"
+					}
+				}
 			}
 		},
 		"@stone-payments/lit-html": {
@@ -94,11 +131,6 @@
 				"no-case": "^2.2.0"
 			}
 		},
-		"faker": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
-			"integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
-		},
 		"header-case": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
@@ -141,6 +173,14 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+		},
+		"lit-element": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.2.0.tgz",
+			"integrity": "sha512-Mzs3H7IO4wAnpzqreHw6dQqp9IG+h/oN8X9pgNbMZbE7x6B0aNOwP5Nveox/5HE+65ZfW2PeULEjoHkrwpTnuQ==",
+			"requires": {
+				"lit-html": "^1.0.0"
+			}
 		},
 		"lit-html": {
 			"version": "1.1.0",

--- a/packages/emd-basic-field/package.json
+++ b/packages/emd-basic-field/package.json
@@ -10,10 +10,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@stone-payments/emd-basic-icon": "^1.0.0",
-    "@stone-payments/emd-basic-loader": "^1.0.0",
-    "@stone-payments/emd-helpers": "^1.1.2",
-    "@stone-payments/emd-hocs": "^1.1.0",
+    "@stone-payments/emd-basic-icon": "^1.2.0",
+    "@stone-payments/emd-basic-loader": "^1.0.3",
+    "@stone-payments/emd-helpers": "^1.3.0",
+    "@stone-payments/emd-hocs": "^1.3.0",
     "@stone-payments/lit-html": "^1.1.0",
     "imask": "^5.2.1",
     "validator": "^10.11.0"

--- a/packages/emd-basic-field/package.json
+++ b/packages/emd-basic-field/package.json
@@ -15,7 +15,7 @@
     "@stone-payments/emd-helpers": "^1.1.2",
     "@stone-payments/emd-hocs": "^1.1.0",
     "@stone-payments/lit-html": "^1.1.0",
-    "cleave.js": "^1.4.7",
+    "imask": "^5.2.1",
     "validator": "^10.11.0"
   },
   "peerDependencies": {

--- a/packages/emd-basic-field/public/index.css
+++ b/packages/emd-basic-field/public/index.css
@@ -40,34 +40,34 @@ emd-field {
   font-size: 14px;
 }
 
-emd-field:nth-of-type(22) {
+emd-field:nth-of-type(23) {
   --emd-field-padding: 0.5em;
 }
 
-emd-field:nth-of-type(23) {
+emd-field:nth-of-type(24) {
   --emd-field-padding: 0.75em;
 }
 
-emd-field:nth-of-type(24) {
+emd-field:nth-of-type(25) {
   --emd-field-padding: 1em;
 }
 
-emd-field:nth-of-type(25) {
+emd-field:nth-of-type(26) {
   --emd-field-padding: 1.5em;
 }
 
-emd-field:nth-of-type(26) {
+emd-field:nth-of-type(27) {
   font-size: 14px;
 }
 
-emd-field:nth-of-type(27) {
+emd-field:nth-of-type(28) {
   font-size: 16px;
 }
 
-emd-field:nth-of-type(28) {
+emd-field:nth-of-type(29) {
   font-size: 18px;
 }
 
-emd-field:nth-of-type(29) {
+emd-field:nth-of-type(30) {
   font-size: 20px;
 }

--- a/packages/emd-basic-field/public/index.html
+++ b/packages/emd-basic-field/public/index.html
@@ -39,11 +39,12 @@
   <emd-field type="email" name="email" autocomplete="on" validationstatus="success"></emd-field>
 
   <h1>Field&thinsp;—&thinsp;Masked</h1>
+  <emd-field type="billet" placeholder="Billet"></emd-field>
   <emd-field type="cep" placeholder="CEP"></emd-field>
   <emd-field type="cnpj" placeholder="CNPJ"></emd-field>
   <emd-field type="cpf" placeholder="CPF"></emd-field>
-  <emd-field type="tel" placeholder="Telephone"></emd-field>
   <emd-field type="money" placeholder="Money"></emd-field>
+  <emd-field type="tel" placeholder="Telephone"></emd-field>
 
   <h1>Field&thinsp;—&thinsp;Padding</h1>
   <emd-field value="Daft Punk" validationstatus="success"></emd-field>

--- a/packages/emd-basic-field/src/component/FieldController.js
+++ b/packages/emd-basic-field/src/component/FieldController.js
@@ -7,8 +7,6 @@ export const FieldController = (Base = class {}) => class extends Base {
     this.attachShadow({ mode: 'open' });
     this.renderRoot = this.shadowRoot;
     this.renderer = render;
-
-    this._handleMaskedValueUpdate = this._handleMaskedValueUpdate.bind(this);
   }
 
   connectedCallback () {
@@ -31,29 +29,26 @@ export const FieldController = (Base = class {}) => class extends Base {
     if (!this.field) {
       this._initialValue = value;
     } else if (pastValue !== nextValue) {
-      this.field.value = nextValue;
-
-      if (this.mask) {
-        this.mask.setRawValue(nextValue);
+      if (!this.mask) {
+        this.field.value = nextValue;
       } else {
-        this.dispatchEventAndMethod('update', nextValue);
+        this.mask.unmaskedValue = nextValue;
       }
+      this.dispatchEventAndMethod('update', nextValue);
     }
   }
 
   _handleFieldInput (evt) {
-    if (!this.mask) {
-      this.dispatchEventAndMethod('update', this.field.value);
-    }
+    const value = !this.mask
+      ? this.field.value
+      : this.mask.unmaskedValue;
+
+    this.dispatchEventAndMethod('update', value);
     evt.stopPropagation();
   }
 
   _handleFieldChange (evt) {
     evt.stopPropagation();
-  }
-
-  _handleMaskedValueUpdate ({ target }) {
-    this.dispatchEventAndMethod('update', target.rawValue);
   }
 
   _updateView () {

--- a/packages/emd-basic-field/src/core.js
+++ b/packages/emd-basic-field/src/core.js
@@ -21,6 +21,9 @@ import { maskCep } from './types/cep/maskCep.js';
 
 import { maskMoney } from './types/money/maskMoney.js';
 
+import { validateBillet } from './types/billet/validateBillet.js';
+import { maskBillet } from './types/billet/maskBillet.js';
+
 const withComponentAndFields = compose(
   withFieldType('email', validateEmail, undefined),
   withFieldType('tel', validateTel, maskTel),
@@ -28,6 +31,7 @@ const withComponentAndFields = compose(
   withFieldType('cnpj', validateCnpj, maskCnpj),
   withFieldType('cep', validateCep, maskCep),
   withFieldType('money', undefined, maskMoney),
+  withFieldType('billet', validateBillet, maskBillet),
   withField,
   withComponent
 );

--- a/packages/emd-basic-field/src/helpers/maskMaker.js
+++ b/packages/emd-basic-field/src/helpers/maskMaker.js
@@ -1,7 +1,17 @@
-import Cleave from 'cleave.js';
-import 'cleave.js/dist/addons/cleave-phone.br';
+import iMask from 'imask';
 
-const noop = () => {};
+// This monkey patch fixes the way iMask detects if an input is currently
+// active since, in our case, we must look for the shadowRoot.activeElement
+// and not the document.activeElement.
 
-export const maskMaker = config => (domEl, onValueChanged = noop) =>
-  new Cleave(domEl, { ...config, onValueChanged });
+Object.defineProperty(iMask.HTMLMaskElement.prototype, 'isActive', {
+  get () {
+    const rootElement = this.input.getRootNode
+      ? this.input.getRootNode() || document
+      : document;
+
+    return this.input === rootElement.activeElement;
+  }
+});
+
+export const maskMaker = config => domEl => iMask(domEl, config);

--- a/packages/emd-basic-field/src/hocs/withFieldType.js
+++ b/packages/emd-basic-field/src/hocs/withFieldType.js
@@ -19,7 +19,7 @@ export const withFieldType = (type, validateFn, maskFn) =>
           : noop;
 
         if (isFunction(maskFn)) {
-          this.mask = maskFn(this.field, this._handleMaskedValueUpdate);
+          this.mask = maskFn(this.field);
         }
       }
     }

--- a/packages/emd-basic-field/src/types/billet/maskBillet.js
+++ b/packages/emd-basic-field/src/types/billet/maskBillet.js
@@ -1,0 +1,15 @@
+import { maskMaker } from '../../helpers/maskMaker.js';
+
+export const maskBillet = maskMaker({
+  mask: [{
+    mask: '00000000000-0 00000000000-0 00000000000-0 00000000000-0',
+    startsWith: '8'
+  }, {
+    mask: '00000.00000 00000.000000 00000.000000 0 00000000000000',
+    startsWith: ''
+  }],
+  dispatch: function (appended, { value, compiledMasks }) {
+    return compiledMasks.find(mask =>
+      `${value}${appended}`.startsWith(mask.startsWith));
+  }
+});

--- a/packages/emd-basic-field/src/types/billet/validateBillet.js
+++ b/packages/emd-basic-field/src/types/billet/validateBillet.js
@@ -1,0 +1,5 @@
+import { isValidBarcode } from '@stone-payments/emd-helpers';
+
+export const validateBillet = value => (value && !isValidBarcode(value)
+  ? 'Deve ser um código de barras válido'
+  : undefined);

--- a/packages/emd-basic-field/src/types/billet/validateBillet.spec.js
+++ b/packages/emd-basic-field/src/types/billet/validateBillet.spec.js
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import { validateBillet } from './validateBillet.js';
+
+describe('validateBillet', () => {
+  it('Should return undefined when receiving no arguments', () => {
+    expect(validateBillet()).to.be.undefined;
+  });
+
+  it('Should return undefined when receiving empty string', () => {
+    expect(validateBillet('')).to.be.undefined;
+  });
+
+  it('Should return message when receiving invalid value', () => {
+    const barcode = {
+      caseOne: 'XXX9999999-X 99999999999-9 99999999999-C 99999999999-A',
+      caseTwo: 'ABC45678d12398-391203821397083921372173-832932',
+      caseThree: '///&**(*$(#$#&ˆ$ˆ&%@@#ˆ$#@%'
+    };
+
+    expect(validateBillet(barcode.caseOne)).to.be.a('string');
+    expect(validateBillet(barcode.caseTwo)).to.be.a('string');
+    expect(validateBillet(barcode.caseThree)).to.be.a('string');
+  });
+
+  it('Should return undefined when receiving a valid string', () => {
+    const barcode = {
+      billet: '99999999999-9 99999999999-9 99999999999-9 99999999999-9',
+      convenio: '85555.55555 55555.555555 55555.555555 5 55555555555555',
+      outher: '59999999999-9 99999999999-9 99999999999-9 99999999999-9'
+    };
+
+    expect(validateBillet(barcode.billet)).to.be.undefined;
+    expect(validateBillet(barcode.convenio)).to.be.undefined;
+    expect(validateBillet(barcode.outher)).to.be.undefined;
+  });
+});

--- a/packages/emd-basic-field/src/types/cep/maskCep.js
+++ b/packages/emd-basic-field/src/types/cep/maskCep.js
@@ -1,7 +1,5 @@
 import { maskMaker } from '../../helpers/maskMaker.js';
 
 export const maskCep = maskMaker({
-  numericOnly: true,
-  delimiter: '-',
-  blocks: [5, 3]
+  mask: '00000-000'
 });

--- a/packages/emd-basic-field/src/types/cnpj/maskCnpj.js
+++ b/packages/emd-basic-field/src/types/cnpj/maskCnpj.js
@@ -1,7 +1,5 @@
 import { maskMaker } from '../../helpers/maskMaker.js';
 
 export const maskCnpj = maskMaker({
-  numericOnly: true,
-  delimiters: ['.', '.', '/', '-'],
-  blocks: [2, 3, 3, 4, 2]
+  mask: '00.000.000/0000-00'
 });

--- a/packages/emd-basic-field/src/types/cpf/maskCpf.js
+++ b/packages/emd-basic-field/src/types/cpf/maskCpf.js
@@ -1,7 +1,5 @@
 import { maskMaker } from '../../helpers/maskMaker.js';
 
 export const maskCpf = maskMaker({
-  numericOnly: true,
-  delimiters: ['.', '.', '-'],
-  blocks: [3, 3, 3, 2]
+  mask: '000.000.000-00'
 });

--- a/packages/emd-basic-field/src/types/money/maskMoney.js
+++ b/packages/emd-basic-field/src/types/money/maskMoney.js
@@ -1,10 +1,13 @@
 import { maskMaker } from '../../helpers/maskMaker.js';
 
 export const maskMoney = maskMaker({
-  numeral: true,
-  prefix: 'R$ ',
-  numeralDecimalMark: ',',
-  delimiter: '.',
-  noImmediatePrefix: true,
-  rawValueTrimPrefix: true
+  mask: 'R$ num',
+  blocks: {
+    num: {
+      mask: Number,
+      thousandsSeparator: '.',
+      padFractionalZeros: true,
+      signed: true
+    }
+  }
 });

--- a/packages/emd-basic-field/src/types/tel/maskTel.js
+++ b/packages/emd-basic-field/src/types/tel/maskTel.js
@@ -1,6 +1,9 @@
 import { maskMaker } from '../../helpers/maskMaker.js';
 
 export const maskTel = maskMaker({
-  phone: true,
-  phoneRegionCode: 'BR'
+  mask: [{
+    mask: '(00) 0000-0000'
+  }, {
+    mask: '(00) 00000-0000'
+  }]
 });


### PR DESCRIPTION
## Description

This PR changes the library we use for masking inputs from [CleaveJS](https://nosir.github.io/cleave.js/) to the more powerful [iMaskJS](https://imask.js.org/).

It made possible to create masks that change dynamically during typing:
- Phone masks now can have either `(00) 0000-0000` or `(00) 00000-0000` formats;
- There's a new field type for barcodes which also changes dynamically while typing.

I wanted to make the money field always consider decimals, like the value was being divided by 100, but I could not figure out how to do it this time.

<img width="560" alt="Captura de Tela 2019-09-24 às 17 18 53" src="https://user-images.githubusercontent.com/125764/65547332-acd98f80-deef-11e9-9a6b-25c7e7f1b8b8.png">

## Run
```
npm install
npm start emd-basic-field
```

## Test
```
npm install
npm test
```

I did test the component on IE Edge using browser stack.
