### PR TITLE
Feature – New component Loading Wrapper

### DIFF
--- a/packages/emd-basic-state-wrapper/public/index.html
+++ b/packages/emd-basic-state-wrapper/public/index.html
@@ -35,6 +35,15 @@
 
   <div>
     <h1>
+      State Wrapper – Loading Only
+    </h1>
+    <emd-state-wrapper ignoreerrors ignoresource>
+      <emd-table></emd-table>
+    </emd-state-wrapper>
+  </div>
+
+  <div>
+    <h1>
       State Wrapper&thinsp;—&thinsp;Custom state
     </h1>
     <emd-state-wrapper>

--- a/packages/emd-basic-state-wrapper/src/component/StateWrapperController.js
+++ b/packages/emd-basic-state-wrapper/src/component/StateWrapperController.js
@@ -36,6 +36,14 @@ export const StateWrapperController = (Base = class {}) =>
         recovery: {
           type: Function,
           reflect: false
+        },
+        ignoreerrors: {
+          type: Boolean,
+          reflect: true
+        },
+        ignoresource: {
+          type: Boolean,
+          reflect: true
         }
       };
     }

--- a/packages/emd-basic-state-wrapper/src/component/StateWrapperView.js
+++ b/packages/emd-basic-state-wrapper/src/component/StateWrapperView.js
@@ -4,11 +4,19 @@ import '@stone-payments/emd-basic-loader';
 import { stateNames } from '../constants/stateNames.js';
 import { getViewCssVariant } from './helpers/getViewCssVariant.js';
 
-const { DEFAULT, RECOVERY } = stateNames;
+const { DEFAULT, PRISTINE, EMPTY, RECOVERY, ERROR } = stateNames;
 
-const getStateClass = (state, currentState) => 'emd-state-wrapper__state' +
-  ` emd-state-wrapper__state_${state.name}` +
-  (currentState === state.name ? ' emd-state-wrapper__state_current' : '');
+const getStateClass = (state, currentState, ignoreerrors, ignoresource) => {
+  const current = currentState === state.name;
+
+  console.log('ignoreerrors', ignoreerrors, currentState);
+  console.log('ignoresource', ignoresource, currentState);
+  console.log('------');
+
+  return 'emd-state-wrapper__state' +
+  ` emd-state-wrapper__state_${current ? state.name : DEFAULT}` +
+  (current ? ' emd-state-wrapper__state_current' : '');
+};
 
 const getWrapperClass = isLoading => 'emd-state-wrapper__wrapper' +
   (isLoading ? ' emd-state-wrapper__wrapper_loading' : '');
@@ -43,7 +51,9 @@ export const StateWrapperView = ({
   currentState,
   wrapped,
   recovery,
-  view
+  view,
+  ignoreerrors,
+  ignoresource
 }) => html`
   <style>
     @import url("emd-basic-state-wrapper/src/component/StateWrapper.css")
@@ -53,7 +63,7 @@ export const StateWrapperView = ({
       <emd-loader class="emd-state-wrapper__loader" loading></emd-loader>
     </div>
     ${states.map(state => html`
-      <div class="${getStateClass(state, currentState)}">
+      <div class="${getStateClass(state, currentState, ignoreerrors, ignoresource)}">
         <div class="emd-state-wrapper__inner">
           ${state.name !== DEFAULT ? html`
             <slot name="${state.name}">


### PR DESCRIPTION
## Description

State Wrapper was designed to handle loading events, errors and empty sources. Except for some intrusive CSS, it works ok, but also tries do to too much.

This new component, Loading Wrapper, specializes in dealing with the loading state only. It shows a spinner and fades the child component if it is loading.

<img width="587" alt="Captura de Tela 2019-10-02 às 12 03 20" src="https://user-images.githubusercontent.com/125764/66056316-5088f800-e50d-11e9-9157-e98241c6b8d7.png">

It also has a new property, called `screenaware`, that allows the spinner to always be visible on the screen if the component is too tall.

<img width="582" alt="Captura de Tela 2019-10-02 às 12 03 41" src="https://user-images.githubusercontent.com/125764/66056427-744c3e00-e50d-11e9-95de-b34e7ac53ab3.png">

<img width="589" alt="Captura de Tela 2019-10-02 às 12 03 53" src="https://user-images.githubusercontent.com/125764/66056432-77dfc500-e50d-11e9-8121-e05276965095.png">

Some visual aspects are configurable via CSS properties: `--emd-loading-wrapper-opacity`, `--emd-loading-wrapper-transition-speed` and `--emd-loading-wrapper-opacity`.

## To run

```
npm install
npm run emd-basic-loading-wrapper
```