### PR TITLE
Feature/portal 79780 Add more brands to brand icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9981,7 +9981,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10002,12 +10003,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10022,17 +10025,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10149,7 +10155,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10161,6 +10168,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10175,6 +10183,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10182,12 +10191,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10206,6 +10217,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10286,7 +10298,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10298,6 +10311,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10383,7 +10397,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10419,6 +10434,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10438,6 +10454,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10481,12 +10498,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/emd-basic-brand-icon/package-lock.json
+++ b/packages/emd-basic-brand-icon/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@stone-payments/emd-assets": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-assets/-/emd-assets-1.4.0.tgz",
-			"integrity": "sha512-Wz/a0C+RecQtWVThgPxps4GU/yJwwJb+Vgodp1bcDJgHGsMOU3EFnGVo+fGvrYuhn+7i6E9BGytwmvoQ/tIxUA==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-assets/-/emd-assets-1.8.0.tgz",
+			"integrity": "sha512-po8E3GGT9GgKTG71g4E8ULJs4AEsTym8ve4daHBWfpMCx9lc9G3b+XJCkungUY52UX8VYNC39ddI2M52scSbHQ==",
 			"requires": {
 				"@stone-payments/emd-helpers": "^1.1.1"
 			}

--- a/packages/emd-basic-brand-icon/package.json
+++ b/packages/emd-basic-brand-icon/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@stone-payments/emd-assets": "^1.4.0",
+    "@stone-payments/emd-assets": "^1.8.0",
     "@stone-payments/emd-basic-icon": "^1.2.0",
     "@stone-payments/emd-helpers": "^1.3.0",
     "@stone-payments/emd-hocs": "^1.3.0",

--- a/packages/emd-basic-brand-icon/src/component/BrandIcon.css
+++ b/packages/emd-basic-brand-icon/src/component/BrandIcon.css
@@ -29,9 +29,15 @@
   padding-right: calc(0.125 * var(--default));
 }
 
+.emd-brand-icon__wrapper_banescard {
+  width: calc(1.05 * var(--default));
+  padding-bottom: 0;
+  padding-right: calc(0.125 * var(--default));
+}
+
 .emd-brand-icon__wrapper_boleto,
 .emd-brand-icon__wrapper_barcode {
-    width: calc(1.05 * var(--default));
+  width: calc(1.05 * var(--default));
   padding-bottom: 0;
   padding-right: calc(0.125 * var(--default));
 }
@@ -64,12 +70,23 @@
   padding-bottom: 0;
 }
 
+.emd-brand-icon__wrapper_up,
+.emd-brand-icon__wrapper_up-brasil {
+  width: calc(1.175 * var(--default));
+  padding-bottom: 0;
+}
+
 .emd-brand-icon__wrapper_senff {
   width: calc(1.175 * var(--default));
   padding-bottom: 0;
 }
 
 .emd-brand-icon__wrapper_sodexo {
+  width: calc(1.42 * var(--default));
+  padding-bottom: calc(0.2 * var(--default));
+}
+
+.emd-brand-icon__wrapper_sorocred {
   width: calc(1.42 * var(--default));
   padding-bottom: calc(0.2 * var(--default));
 }
@@ -87,7 +104,7 @@
 
 .emd-brand-icon__wrapper_vr,
 .emd-brand-icon__wrapper_vr-beneficios {
-    width: calc(0.86 * var(--default));
+  width: calc(0.86 * var(--default));
   padding-bottom: 0;
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Upgrades minimum `emd-assets` version on brand icon basic component and adds style options to the new brands. 

### Screenshots
![image](https://user-images.githubusercontent.com/36934206/66439718-f43f4000-ea06-11e9-8db7-e13d2214b327.png)
