### PR TITLE
Fix – Brand Icon logo sizes

### DIFF
--- a/packages/emd-basic-brand-icon/src/component/BrandIcon.css
+++ b/packages/emd-basic-brand-icon/src/component/BrandIcon.css
@@ -43,7 +43,8 @@
 }
 
 .emd-brand-icon__wrapper_cooper,
-.emd-brand-icon__wrapper_coopercard {
+.emd-brand-icon__wrapper_coopercard,
+.emd-brand-icon__wrapper_cooper-card {
   width: calc(0.94 * var(--default));
   padding-bottom: 0;
 }
@@ -72,7 +73,7 @@
 
 .emd-brand-icon__wrapper_up,
 .emd-brand-icon__wrapper_up-brasil {
-  width: calc(1.175 * var(--default));
+  width: calc(1.1 * var(--default));
   padding-bottom: 0;
 }
 
@@ -92,7 +93,7 @@
 }
 
 .emd-brand-icon__wrapper_ticket {
-  width: calc(1.5 * var(--default));
+  width: calc(1.6 * var(--default));
   padding-bottom: 0;
 }
 
@@ -104,7 +105,7 @@
 
 .emd-brand-icon__wrapper_vr,
 .emd-brand-icon__wrapper_vr-beneficios {
-  width: calc(0.86 * var(--default));
+  width: calc(0.825 * var(--default));
   padding-bottom: 0;
 }
 


### PR DESCRIPTION
Fix Sorocred icon sizes and adjust some others.

Before:
<img width="1441" alt="Captura de Tela 2019-10-08 às 20 51 10" src="https://user-images.githubusercontent.com/125764/66441475-69ae0f00-ea0d-11e9-800a-d21a24584ac4.png">

After:
<img width="1403" alt="Captura de Tela 2019-10-08 às 20 52 30" src="https://user-images.githubusercontent.com/125764/66441512-93ffcc80-ea0d-11e9-94bd-9eaba00c3034.png">

