### PR TITLE
Hot Fix – Restrict rowclick events to clickable rows [MASTER]

### DIFF
--- a/packages/emd-basic-table/src/component/TableController.js
+++ b/packages/emd-basic-table/src/component/TableController.js
@@ -210,17 +210,19 @@ export const TableController = (Base = class {}) =>
       return true;
     }
 
-    handleRowClick (index) {
+    handleRowClick (rowIndex) {
       return () => {
-        if (this.clickablerows) {
-          this.dispatchEventAndMethod('rowclick', this.rows[index]);
+        const row = this.rows[rowIndex];
+        if (this.getRowClickability(row, rowIndex)) {
+          this.dispatchEventAndMethod('rowclick', row);
         }
       };
     }
 
-    dispatchCustomEvent (index) {
+    dispatchCustomEvent (rowIndex) {
       return evtName => () => {
-        this.dispatchEventAndMethod(evtName, this.rows[index]);
+        const row = this.rows[rowIndex];
+        this.dispatchEventAndMethod(evtName, row);
       };
     }
 

--- a/packages/emd-basic-table/src/component/TableController.spec.js
+++ b/packages/emd-basic-table/src/component/TableController.spec.js
@@ -367,6 +367,23 @@ describe('TableController', () => {
 
       expect(dummy.dispatchEventAndMethod).not.to.have.been.called;
     });
+
+    it('Should not dispatch an event if a specific row ' +
+      'is not clickable', () => {
+      const firstRow = {};
+      const secondRow = {};
+      dummy.rows = [firstRow, secondRow];
+
+      dummy.clickablerows = true;
+      dummy.clickableadapter = row => row !== firstRow;
+      dummy.dispatchEventAndMethod = sinon.spy();
+
+      dummy.handleRowClick(0)();
+      dummy.handleRowClick(1)();
+
+      expect(dummy.dispatchEventAndMethod)
+        .to.have.been.calledOnceWith('rowclick', secondRow);
+    });
   });
 
   describe('#dispatchCustomEvent()', () => {


### PR DESCRIPTION
Restrict `rowclick` events to clickable rows