### PR TITLE
feat: Add two new input types: `bank-account` and `integer`

### DIFF
--- a/packages/emd-basic-field/public/index.css
+++ b/packages/emd-basic-field/public/index.css
@@ -40,34 +40,34 @@ emd-field {
   font-size: 14px;
 }
 
-emd-field:nth-of-type(24) {
+emd-field:nth-of-type(26) {
   --emd-field-padding: 0.5em;
 }
 
-emd-field:nth-of-type(25) {
+emd-field:nth-of-type(27) {
   --emd-field-padding: 0.75em;
 }
 
-emd-field:nth-of-type(26) {
+emd-field:nth-of-type(28) {
   --emd-field-padding: 1em;
 }
 
-emd-field:nth-of-type(27) {
+emd-field:nth-of-type(29) {
   --emd-field-padding: 1.5em;
 }
 
-emd-field:nth-of-type(28) {
+emd-field:nth-of-type(30) {
   font-size: 14px;
 }
 
-emd-field:nth-of-type(29) {
+emd-field:nth-of-type(31) {
   font-size: 16px;
 }
 
-emd-field:nth-of-type(30) {
+emd-field:nth-of-type(32) {
   font-size: 18px;
 }
 
-emd-field:nth-of-type(31) {
+emd-field:nth-of-type(33) {
   font-size: 20px;
 }

--- a/packages/emd-basic-field/public/index.html
+++ b/packages/emd-basic-field/public/index.html
@@ -39,12 +39,14 @@
   <emd-field type="email" name="email" autocomplete="on" validationstatus="success"></emd-field>
 
   <h1>Field&thinsp;—&thinsp;Masked</h1>
+  <emd-field type="bank-account" placeholder="Bank Account (with digit)"></emd-field>
   <emd-field type="billet" placeholder="Billet"></emd-field>
   <emd-field type="cep" placeholder="CEP"></emd-field>
   <emd-field type="cnpj" placeholder="CNPJ"></emd-field>
   <emd-field type="cpf" placeholder="CPF"></emd-field>
   <emd-field type="cpf-cnpj" placeholder="CPF or CNPJ"></emd-field>
   <emd-field type="money" placeholder="Money"></emd-field>
+  <emd-field type="integer" placeholder="Numeric (integer)"></emd-field>
   <emd-field type="tel" placeholder="Telephone"></emd-field>
 
   <h1>Field&thinsp;—&thinsp;Padding</h1>

--- a/packages/emd-basic-field/src/core.js
+++ b/packages/emd-basic-field/src/core.js
@@ -27,6 +27,10 @@ import { maskMoney } from './types/money/maskMoney.js';
 import { validateBillet } from './types/billet/validateBillet.js';
 import { maskBillet } from './types/billet/maskBillet.js';
 
+import { maskBankAccount } from './types/bankAccount/maskBankAccount.js';
+
+import { maskInteger } from './types/integer/maskInteger.js';
+
 const withComponentAndFields = compose(
   withFieldType('email', validateEmail, undefined),
   withFieldType('tel', validateTel, maskTel),
@@ -36,6 +40,8 @@ const withComponentAndFields = compose(
   withFieldType('cep', validateCep, maskCep),
   withFieldType('money', undefined, maskMoney),
   withFieldType('billet', validateBillet, maskBillet),
+  withFieldType('bank-account', undefined, maskBankAccount),
+  withFieldType('integer', undefined, maskInteger),
   withField,
   withComponent
 );

--- a/packages/emd-basic-field/src/types/bankAccount/maskBankAccount.js
+++ b/packages/emd-basic-field/src/types/bankAccount/maskBankAccount.js
@@ -1,0 +1,23 @@
+import { maskMaker } from '../../helpers/maskMaker.js';
+
+export const maskBankAccount = maskMaker({
+  mask: [
+    { mask: '0' },
+    { mask: '0-0' },
+    { mask: '00-0' },
+    { mask: '000-0' },
+    { mask: '0000-0' },
+    { mask: '00000-0' },
+    { mask: '000000-0' },
+    { mask: '0000000-0' },
+    { mask: '00000000-0' },
+    { mask: '000000000-0' },
+    { mask: '0000000000-0' },
+    { mask: '00000000000-0' },
+    { mask: '000000000000-0' },
+    { mask: '0000000000000-0' },
+    { mask: '00000000000000-0' },
+    { mask: '000000000000000-0' },
+    { mask: '0000000000000000-0' }
+  ]
+});

--- a/packages/emd-basic-field/src/types/integer/maskInteger.js
+++ b/packages/emd-basic-field/src/types/integer/maskInteger.js
@@ -1,0 +1,5 @@
+import { maskMaker } from '../../helpers/maskMaker.js';
+
+export const maskInteger = maskMaker({
+  mask: /^\d+$/
+});


### PR DESCRIPTION
## Description

Add two new input types, `bank-account` and `integer`.

```html
<emd-field type="bank-account"></emd-field>
```

```html
<emd-field type="integer"></emd-field>
```

## Test

```
npm install
npm test
```

## Run locally

```
npm install
npm start emd-basic-field
```