### PR TITLE
Hot Fix – Prevent component from breaking if its child is removed from the DOM

### DIFF
--- a/packages/emd-basic-loading-wrapper/src/component/LoadingWrapperController.js
+++ b/packages/emd-basic-loading-wrapper/src/component/LoadingWrapperController.js
@@ -88,7 +88,10 @@ export const LoadingWrapperController = (Base = class {}) =>
       if (this._animation) {
         window.cancelAnimationFrame(this._animation);
       }
-      this.child.style = '';
+
+      if (this.child) {
+        this.child.style = '';
+      }
     }
 
     handleLoadingStart () {


### PR DESCRIPTION
## Description

Prevent component from breaking if its child is removed from the DOM.

## Test

````
npm i && npm t
```

## Run locally
```
npm i && npm start emd-basic-loading-wrapper
```