### PR TITLE
Fix – Correct text overflow on Select

### DIFF
--- a/packages/emd-basic-select/src/component/Select.css
+++ b/packages/emd-basic-select/src/component/Select.css
@@ -52,10 +52,11 @@
 
 .emd-field__text {
   flex-grow: 1;
-  flex-shrink: 0;
+  flex-shrink: 1;
   flex-basis: auto;
   display: flex;
   align-items: center;
+  width: 100%;
   height: calc(1.5em + var(--emd-field-padding, 1em) * 2);
   padding: 1px calc(1px + var(--emd-field-padding, 1em));
   box-sizing: content-box;


### PR DESCRIPTION
## Description

Fix Select text overflow.

### Before

![Screen Shot 2019-10-25 at 16 59 33](https://user-images.githubusercontent.com/125764/67600952-940c0600-f749-11e9-96c6-61f46cbc188d.png)

![Screen Shot 2019-10-25 at 17 01 35](https://user-images.githubusercontent.com/125764/67600960-98d0ba00-f749-11e9-91d3-9def5f6baad7.png)

### After

![Screen Shot 2019-10-25 at 17 00 08](https://user-images.githubusercontent.com/125764/67600982-a423e580-f749-11e9-977a-5168da400eb3.png)

![Screen Shot 2019-10-25 at 17 02 01](https://user-images.githubusercontent.com/125764/67600994-a8e89980-f749-11e9-9194-5093751d5457.png)

## Test

```
npm i && npm t
```

## Run locally

```
npm i && npm start emd-basic-select
```