### PR TITLE
fix: Allow Field Wrapper to listen to Fields wrapped in other tags

### DIFF
--- a/packages/emd-basic-field-wrapper/src/component/FieldWrapperController.js
+++ b/packages/emd-basic-field-wrapper/src/component/FieldWrapperController.js
@@ -33,8 +33,7 @@ export const FieldWrapperController = (Base = class {}) =>
     }
 
     get wrapped () {
-      return Array.from(this.children)
-        .find(element => element.matches(fieldSelector));
+      return this.querySelector(fieldSelector);
     }
 
     static getFieldId (field) {


### PR DESCRIPTION
## Description

This PR allows Field Wrapper to listen to Fields wrapped in other tags. This will work:

```html
<emd-field-wrapper>
  <div>
    <emd-field name="user" type="text" required></emd-field>
  </div>
</emd-field-wrapper>
```

## Test
```
npm i && npm t
```

## Run locally
```
npm i && npm start emd-basic-field-wrapper
```