### PR TITLE
Fix – hideicon and readonly

### DIFF
--- a/packages/emd-basic-field/src/component/FieldView.js
+++ b/packages/emd-basic-field/src/component/FieldView.js
@@ -13,7 +13,7 @@ export const FieldView = ({
     ? validationstatus
     : show;
 
-  show = hideicon ? undefined : show;
+  show = hideicon && show !== 'validating' ? undefined : show;
 
   const showClass = 'emd-field__states' +
     (show ? ` emd-field__states_show_${show}` : '');

--- a/packages/emd-basic-select/src/component/SelectController.js
+++ b/packages/emd-basic-select/src/component/SelectController.js
@@ -1,12 +1,15 @@
 import { toString, setAttr } from '@stone-payments/emd-helpers';
 import { render } from '@stone-payments/lit-html';
 
+const TAB_KEY = 9;
+
 export const SelectController = (Base = class {}) => class extends Base {
   constructor () {
     super();
     this.attachShadow({ mode: 'open' });
     this.renderRoot = this.shadowRoot;
     this.renderer = render;
+    this.handleKeydown = this.handleKeydown.bind(this);
   }
 
   connectedCallback () {
@@ -128,6 +131,12 @@ export const SelectController = (Base = class {}) => class extends Base {
 
   _updateView () {
     this.renderer(this.render(), this.renderRoot);
+  }
+
+  handleKeydown (evt) {
+    if (this.readonly && evt.which !== TAB_KEY) {
+      evt.preventDefault();
+    }
   }
 
   render () {

--- a/packages/emd-basic-select/src/component/SelectView.js
+++ b/packages/emd-basic-select/src/component/SelectView.js
@@ -9,7 +9,8 @@ export const SelectView = ({
   selection,
   validating,
   validationstatus,
-  hideicon
+  hideicon,
+  handleKeydown
 }) => {
   let show = validating ? 'validating' : undefined;
 
@@ -17,7 +18,7 @@ export const SelectView = ({
     ? validationstatus
     : show;
 
-  show = hideicon ? undefined : show;
+  show = hideicon && show !== 'validating' ? undefined : show;
 
   const showClass = 'emd-field__states emd-field__states_show_unfold' +
     (show ? ` emd-field__states_show_${show}` : '');
@@ -32,7 +33,9 @@ export const SelectView = ({
     <style>
       @import url("emd-basic-select/src/component/Select.css")
     </style>
-    <div class="emd-field__wrapper${iconsClass}">
+    <div
+      class="emd-field__wrapper${iconsClass}"
+      @keydown="${handleKeydown}">
       <select class="emd-field__select">
         <option
           value=""


### PR DESCRIPTION
## Description

- On Field and Select, prevent the validation icon from being hidden when `hideicon` is on.
- On Select, prevents user interaction via keyboard keys (except Tab) when component is `readonly`

<img width="399" alt="Captura de Tela 2019-10-31 às 11 51 39" src="https://user-images.githubusercontent.com/125764/67957822-f2673780-fbd4-11e9-9b56-ce3ca1d86ff0.png">

<img width="399" alt="Captura de Tela 2019-10-31 às 11 53 32" src="https://user-images.githubusercontent.com/125764/67957918-1591e700-fbd5-11e9-991e-3c356722113a.png">

## Test

```
npm i && npm t
```

## Run locally

```
npm i && npm start emd-basic-field
npm i && npm start emd-basic-select
```