### PR TITLE
Feature — Button click debounce

### DIFF
--- a/packages/emd-basic-button/src/component/ButtonController.js
+++ b/packages/emd-basic-button/src/component/ButtonController.js
@@ -36,7 +36,7 @@ export const ButtonController = (Base = class {}) =>
     }
 
     handleClick (evt) {
-      const clickCount = evt.detail;
+      const clickCount = evt.detail || 1;
 
       if (this.disabled || this.loading ||
         (!this.multipleclicks && clickCount > 1)) {

--- a/packages/emd-basic-button/src/component/ButtonController.js
+++ b/packages/emd-basic-button/src/component/ButtonController.js
@@ -3,7 +3,7 @@ export const ButtonController = (Base = class {}) =>
     constructor () {
       super();
       this.type = 'button';
-      this._handleClick = this._handleClick.bind(this);
+      this.handleClick = this.handleClick.bind(this);
     }
 
     static get properties () {
@@ -27,22 +27,19 @@ export const ButtonController = (Base = class {}) =>
         target: {
           type: String,
           reflect: true
+        },
+        multipleclicks: {
+          type: Boolean,
+          reflect: true
         }
       };
     }
 
-    connectedCallback () {
-      super.connectedCallback();
-      this.addEventListener('click', this._handleClick, true);
-    }
+    handleClick (evt) {
+      const clickCount = evt.detail;
 
-    disconnectedCallback () {
-      super.disconnectedCallback();
-      this.removeEventListener('click', this._handleClick);
-    }
-
-    _handleClick (evt) {
-      if (this.disabled || this.loading) {
+      if (this.disabled || this.loading ||
+        (!this.multipleclicks && clickCount > 1)) {
         evt.stopPropagation();
       }
     }

--- a/packages/emd-basic-button/src/component/ButtonView.js
+++ b/packages/emd-basic-button/src/component/ButtonView.js
@@ -6,7 +6,8 @@ export const ButtonView = ({
   disabled,
   loading,
   href,
-  target = ''
+  target = '',
+  handleClick
 }) => {
   let wrapperClass = 'emd-button__wrapper';
   wrapperClass += loading ? ' emd-button__wrapper_loading' : '';
@@ -16,7 +17,9 @@ export const ButtonView = ({
     <style>
       @import url("emd-basic-button/src/component/Button.css")
     </style>
-    <div class="${wrapperClass}">
+    <div
+      class="${wrapperClass}"
+      @click="${handleClick}">
       <emd-loader
         ?loading="${loading}"
         class="emd-button__loader"></emd-loader>


### PR DESCRIPTION
## Description

Guarantees that the `click` event will one be dispatched once if the button is clicked multiples times in sequence.

This default behavior can be disabled by using `multipleclicks`.

### Before

![Gravação de Tela 2019-11-08 às 14 36 58](https://user-images.githubusercontent.com/125764/68499215-6a69d900-0237-11ea-8ebf-4c9f124da210.gif)

### After

![Gravação de Tela 2019-11-08 às 14 35 09](https://user-images.githubusercontent.com/125764/68499225-7190e700-0237-11ea-8513-b73262638acf.gif)

## Test

```
npm i && npm t
```

## Run locally

```
npm i && npm start emd-basic-button
```