### PR TITLE
Hotfix — Rename delete to remove-circle and fix add-circle

### DIFF
--- a/packages/emd-basic-icon/package-lock.json
+++ b/packages/emd-basic-icon/package-lock.json
@@ -5,29 +5,28 @@
 	"requires": true,
 	"dependencies": {
 		"@stone-payments/emd-assets": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-assets/-/emd-assets-1.7.0.tgz",
-			"integrity": "sha512-cvT+mloM0JYz3uUA7dCxZ6dxpF0a0OjPLcLxCguzQ1HXuGhMXUXXaeJE//EiVkV8Pyjf7TQq5H7b3J4Is6YWIA==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-assets/-/emd-assets-1.9.2.tgz",
+			"integrity": "sha512-3Jr2J03DgQ69tMkoiilBGYhrY77wjk/6ImcyEcU4U5kxiIX7ERqMEEUSZadu2e37pzDLjLk4Goum/8f++wfICg==",
 			"requires": {
 				"@stone-payments/emd-helpers": "^1.1.1"
 			}
 		},
 		"@stone-payments/emd-helpers": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-helpers/-/emd-helpers-1.3.2.tgz",
-			"integrity": "sha512-VZEptOXu+cS1aw1dr0EUK/f0/ZRC0DIrs085m1f7PxwI8K5pJq27cH6qrEV/Z8CmCYyjwT1EEC6AiRKGSJIArw==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-helpers/-/emd-helpers-1.7.0.tgz",
+			"integrity": "sha512-6gkdWQICIstHPk5Y9riEMfFjoSymUVtCAZYdNCgoKaiY+7+VgPfZdx/IAl1HWhceRs+sUcdRIQ+lG5o9hoSGEQ==",
 			"requires": {
 				"bluebird": "3.5.5",
 				"change-case": "^3.1.0",
 				"date-fns": "^1.30.1",
-				"is-plain-object": "^2.0.4",
 				"timm": "^1.6.1"
 			}
 		},
 		"@stone-payments/emd-hocs": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@stone-payments/emd-hocs/-/emd-hocs-1.4.0.tgz",
-			"integrity": "sha512-ts1rzfS9wRkWSasqqWFnU57XEdBt32LCm+AV8f6UQB0W99HcvE5A28HoyZ+ES+rgCSJ1rd/hG873cD019SZHyw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@stone-payments/emd-hocs/-/emd-hocs-2.1.1.tgz",
+			"integrity": "sha512-qgEldNCA8r8n1D+r0KQa2fM9FsiXiQS0pMUNXiEtg1PyFgqAMfQ/HZPeKZ5koWNS1JPDt+bGDFfeBoJjIWDlbw==",
 			"requires": {
 				"@stone-payments/emd-helpers": "^1.1.1"
 			}
@@ -127,14 +126,6 @@
 				"lower-case": "^1.1.0"
 			}
 		},
-		"is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"requires": {
-				"isobject": "^3.0.1"
-			}
-		},
 		"is-upper-case": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
@@ -142,11 +133,6 @@
 			"requires": {
 				"upper-case": "^1.1.0"
 			}
-		},
-		"isobject": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
 		"lit-element": {
 			"version": "2.2.0",

--- a/packages/emd-basic-icon/package.json
+++ b/packages/emd-basic-icon/package.json
@@ -10,10 +10,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@stone-payments/emd-assets": "^1.7.0",
-    "@stone-payments/emd-helpers": "^1.1.2",
-    "@stone-payments/emd-hocs": "^1.1.0",
-    "@stone-payments/lit-element": "^2.2.1"
+    "@stone-payments/emd-assets": "^1.9.2",
+    "@stone-payments/emd-helpers": "^1.7.0",
+    "@stone-payments/emd-hocs": "^2.1.1",
+    "@stone-payments/lit-element": "^2.2.2"
   },
   "peerDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
## Description

Update the package `emd-assets` to rename `delete` to `remove-circle` and fix `add-circle`.

<img width="656" alt="Captura de Tela 2019-12-13 às 11 54 55" src="https://user-images.githubusercontent.com/125764/70808936-8ebd5600-1d9f-11ea-9fcb-be6e9cd02958.png">

## Run locally

```
npm i && npm start emd-basic-icon
```