### PR TITLE
Hotfix — Correct margin of error messages with two or more lines

### DIFF
--- a/packages/emd-basic-field-wrapper/public/index.css
+++ b/packages/emd-basic-field-wrapper/public/index.css
@@ -35,12 +35,3 @@ h4, p {
 button {
   vertical-align: middle;
 }
-
-emd-field-wrapper {
-  font-size: 12px;
-}
-
-emd-field,
-emd-select {
-  font-size: 14px;
-}

--- a/packages/emd-basic-field-wrapper/src/component/FieldWrapper.css
+++ b/packages/emd-basic-field-wrapper/src/component/FieldWrapper.css
@@ -9,7 +9,6 @@
 .emd-field-wrapper__label,
 .emd-field-wrapper__message,
 .emd-field-wrapper__hint {
-  min-height: 1.75em;
   display: flex;
   flex-flow: row nowrap;
   flex-grow: 1;
@@ -17,12 +16,12 @@
 
 .emd-field-wrapper__label {
   font-weight: bold;
-  align-items: flex-start;
+  margin-bottom: 0.4375em;
 }
 
 .emd-field-wrapper__message,
 .emd-field-wrapper__hint {
-  align-items: flex-end;
+  margin-top: 0.4375em;
 }
 
 .emd-field-wrapper__message {


### PR DESCRIPTION
## Description

Correct margin of error messages with two or more lines

### Before

![Screen Shot 2019-12-13 at 14 58 17](https://user-images.githubusercontent.com/125764/70821389-bde0c100-1db9-11ea-81a0-6ea69e90419a.png)

### After

![Screen Shot 2019-12-13 at 14 57 32](https://user-images.githubusercontent.com/125764/70821397-c20cde80-1db9-11ea-80cb-e46c4018a430.png)

## Run locally

```
npm i && npm start emd-basic-field-wrapper
```