### PR TITLE
Hotfix — Fix the height of the empty error message

### DIFF
--- a/packages/emd-basic-field-wrapper/src/component/FieldWrapper.css
+++ b/packages/emd-basic-field-wrapper/src/component/FieldWrapper.css
@@ -9,7 +9,6 @@
 .emd-field-wrapper__label,
 .emd-field-wrapper__message,
 .emd-field-wrapper__hint {
-  min-height: 1.3125em;
   display: flex;
   flex-flow: row nowrap;
   flex-grow: 1;

--- a/packages/emd-basic-field-wrapper/src/component/FieldWrapperView.js
+++ b/packages/emd-basic-field-wrapper/src/component/FieldWrapperView.js
@@ -16,6 +16,6 @@ export const FieldWrapperView = ({
   ${message ? html`
     <div class="emd-field-wrapper__message">${message}</div>
   ` : (hint != null && hint !== '') || emptyhint ? html`
-    <div class="emd-field-wrapper__hint">${hint}</div>
+    <div class="emd-field-wrapper__hint">${hint || html`&nbsp;`}</div>
   ` : ''}
 `;


### PR DESCRIPTION
## Description

This PR fixes the way the height of the empty error message is calculated, so that showing and hiding and error won't make the content below moves.

### Before

Note how the content below the field slightly moves up and down when the error message is shown or hidden.

![Gravação de Tela 2019-12-20 às 10 43 33](https://user-images.githubusercontent.com/125764/71259973-7bb70280-2318-11ea-8396-8cd14f6cee50.gif)


### After

![Gravação de Tela 2019-12-20 às 10 42 45](https://user-images.githubusercontent.com/125764/71259979-7f4a8980-2318-11ea-857c-d89bd3e66143.gif)


## Test

```
npm i && npm t
```

## Run locally

```
npm i && npm start emd-basic-field-wrapper
```