### PR TITLE
Feature — Add Storybook and Readme documentation for the Emerald Button

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -2,6 +2,7 @@ import { configure } from '@storybook/vue';
 import './style.css';
 
 const loadStories = () => {
+  require('../packages/emd-basic-button/src/component/Button.stories.js');
   require('../packages/emd-basic-login/src/component/Login.stories.js');
 }
 

--- a/packages/emd-basic-button/README.md
+++ b/packages/emd-basic-button/README.md
@@ -1,0 +1,82 @@
+# Button
+
+Emerald Button UI component.
+
+## Usage
+
+```html
+<emd-button>
+  Click me
+</emd-button>
+
+<emd-button>
+  <emd-icon icon="arrow-up"></emd-icon>
+  Move up
+</emd-button>
+
+<emd-button loading>
+  Buy now
+</emd-button>
+
+<emd-button href="http://stone.co">
+  Stone Co.
+</emd-button>
+```
+
+## Attributes and Properties
+
+#### `type`
+
+Defines the type of the component. It can be: `button`, `submit` or `reset`. This attribute is passed to the `<button>` element inside the component.
+
+- Type: String
+- Attribute and property
+
+#### `disabled`
+
+Disables the component.
+
+- Type: Boolean
+- Attribute and property
+
+#### `loading`
+
+Shows a loading spinner inside the component.
+
+- Type: Boolean
+- Attribute and property
+
+#### `href`
+
+Makes the component behave like an `<a>` tag.
+
+- Type: String
+- Attribute and property
+
+#### `target`
+
+Defines the tab where the url set in the `href` attribute will be loaded.
+
+- Type: String
+- Attribute and property
+
+#### `multipleclicks`
+
+Allows the component to recognize multiple clicks in a row. By default, when clicked multiple times in a row, the component will only recognize the first click.
+
+- Type: Boolean
+- Attribute and property
+
+## CSS Properties
+
+#### `--emd-button-padding`
+
+Controlls the internal padding of the button.
+
+- Default: `1.125em 1.5em`
+
+## Slots
+
+#### Default
+
+The component's content. Usually some text, but it can also be an image or an icon, for example.

--- a/packages/emd-basic-button/src/component/Button.stories.js
+++ b/packages/emd-basic-button/src/component/Button.stories.js
@@ -1,0 +1,217 @@
+import { storiesOf } from '@storybook/vue';
+import { withKnobs, text, number, boolean, select, color } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+import readMe from '../../README.md';
+import '../index.js';
+
+const fontOptions = {
+  range: true,
+  min: 12,
+  max: 24,
+  step: 1
+};
+
+const logEvent = ({ type, detail }) => {
+  action(type)(detail);
+};
+
+storiesOf('Button', module)
+  .addDecorator(withKnobs)
+  .add('Default', () => ({
+    methods: {
+      logEvent
+    },
+    props: {
+      text: {
+        default: text('Content', 'Click me')
+      },
+      fontSize: {
+        default: number('Font size', 16, fontOptions)
+      },
+      type: {
+        default: select('Type', ['button', 'submit', 'reset'], 'button')
+      },
+      disabled: {
+        default: boolean('Disabled')
+      },
+      loading: {
+        default: boolean('Loading')
+      }
+    },
+    template: `
+      <div :style="{ fontSize: fontSize + 'px' }">
+        <emd-button
+          :type="type"
+          :disabled.prop="disabled"
+          :loading.prop="loading"
+          @click="logEvent"
+        >
+          {{ text }}
+        </emd-button>
+      </div>
+    `
+  }), {
+    notes: { markdown: readMe }
+  })
+  .add('With Custom Style', () => ({
+    methods: {
+      logEvent
+    },
+    props: {
+      text: {
+        default: text('Content', 'Click me')
+      },
+      fontSize: {
+        default: number('Font size', 16, fontOptions)
+      },
+      padding: {
+        default: text('Padding (--emd-button-padding)', '1em 4em')
+      },
+      borderRadius: {
+        default: text('Border radius', '1em')
+      },
+      color: {
+        default: color('Text color', '#fff')
+      },
+      backgroundColor: {
+        default: color('Background color', '#088037')
+      },
+      borderColor: {
+        default: color('Border color', '#088037')
+      },
+      disabledColor: {
+        default: color('Disabled text color', '#fff')
+      },
+      disabledBackgroundColor: {
+        default: color('Disabled background color', '#c3c8d2')
+      },
+      disabledBorderColor: {
+        default: color('Disabled border color', '#c3c8d2')
+      },
+      type: {
+        default: select('Type', ['button', 'submit', 'reset'], 'button')
+      },
+      disabled: {
+        default: boolean('Disabled')
+      },
+      loading: {
+        default: boolean('Loading')
+      }
+    },
+    computed: {
+      customStyle () {
+        return !this.disabled
+          ? {
+            color: this.color,
+            backgroundColor: this.backgroundColor,
+            borderColor: this.borderColor,
+            borderRadius: this.borderRadius,
+            '--emd-button-padding': this.padding
+          }
+          : {
+            color: this.disabledColor,
+            backgroundColor: this.disabledBackgroundColor,
+            borderColor: this.disabledBorderColor,
+            borderRadius: this.borderRadius,
+            '--emd-button-padding': this.padding
+          };
+      }
+    },
+    template: `
+      <div
+        :style="{ fontSize: fontSize + 'px' }"
+      >
+        <emd-button
+          :style="customStyle"
+          :type="type"
+          :disabled.prop="disabled"
+          :loading.prop="loading"
+          @click="logEvent"
+        >
+          {{ text }}
+        </emd-button>
+      </div>
+    `
+  }), {
+    notes: { markdown: readMe }
+  })
+  .add('With Link', () => ({
+    methods: {
+      logEvent
+    },
+    props: {
+      fontSize: {
+        default: number('Font size', 16, fontOptions)
+      },
+      href: {
+        default: text('Href', 'http://stone.co')
+      },
+      target: {
+        default: text('Target', '_blank')
+      }
+    },
+    template: `
+      <div
+        :style="{ fontSize: fontSize + 'px' }"
+      >
+        <emd-button
+          :href="href"
+          :target="target"
+          @click="logEvent"
+        >
+          Go to {{ href }}
+        </emd-button>
+      </div>
+    `
+  }), {
+    notes: { markdown: readMe }
+  })
+  .add('With Multiple Clicks', () => ({
+    methods: {
+      addCountFast (evt) {
+        this.fast += 1;
+        logEvent(evt);
+      },
+      addCountSlow (evt) {
+        this.slow += 1;
+        logEvent(evt);
+      }
+    },
+    data () {
+      return {
+        fast: 0,
+        slow: 0
+      };
+    },
+    props: {
+      fontSize: {
+        default: number('Font size', 16, fontOptions)
+      }
+    },
+    template: `
+      <div
+        style="display: grid; grid-gap: 1em; grid-template-columns: 1fr 2fr; align-items: center;"
+        :style="{ fontSize: fontSize + 'px' }"
+      >
+        <emd-button
+          @click="addCountSlow"
+        >
+          Multiple clicks (disabled)
+        </emd-button>
+        <p>
+          Click count: {{ slow }}
+        </p>
+        <emd-button
+          @click="addCountFast"
+          multipleclicks
+        >
+          Multiple clicks (enabled)
+        </emd-button>
+        <p>
+          Click count: {{ fast }}
+        </p>
+      </div>
+    `
+  }), {
+    notes: { markdown: readMe }
+  });


### PR DESCRIPTION
## Description

This PR adds Storybook and Readme documentation for the Emerald Button.

Please read, try and see if you can spot any mistakes!

<img width="1538" alt="Captura de Tela 2019-12-30 às 18 04 01" src="https://user-images.githubusercontent.com/125764/71600808-61a6cc80-2b2f-11ea-9057-5be42c6870f2.png">

<img width="1538" alt="Captura de Tela 2019-12-30 às 18 05 07" src="https://user-images.githubusercontent.com/125764/71600811-653a5380-2b2f-11ea-8bc1-f765627feaa1.png">

<img width="1538" alt="Captura de Tela 2019-12-30 às 18 05 23" src="https://user-images.githubusercontent.com/125764/71600815-679cad80-2b2f-11ea-9a7c-fe8179536566.png">

<img width="1538" alt="Captura de Tela 2019-12-30 às 18 05 44" src="https://user-images.githubusercontent.com/125764/71600817-69ff0780-2b2f-11ea-9d30-1b65ca88b2c6.png">

<img width="1538" alt="Captura de Tela 2019-12-30 às 18 04 46" src="https://user-images.githubusercontent.com/125764/71600820-6cf9f800-2b2f-11ea-9e1b-34473a98a187.png">

## Test

```
npm i && npm t
```

## Open Storybook

```
npm i && npm run storybook
```

## Run the component locally

```
npm i && npm start emd-basic-button
```