### PR TITLE
Feature — Add README and Storybook for Money

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -5,6 +5,7 @@ const loadStories = () => {
   require('../packages/emd-basic-button/src/component/Button.stories.js');
   require('../packages/emd-basic-card/src/component/Card.stories.js');
   require('../packages/emd-basic-login/src/component/Login.stories.js');
+  require('../packages/emd-basic-money/src/component/Money.stories.js');
 }
 
 configure(loadStories, module);

--- a/packages/emd-basic-button/src/component/Button.stories.js
+++ b/packages/emd-basic-button/src/component/Button.stories.js
@@ -22,11 +22,11 @@ storiesOf('Button', module)
       logEvent
     },
     props: {
-      text: {
-        default: text('Content', 'Click me')
-      },
       fontSize: {
         default: number('Font size', 16, fontOptions)
+      },
+      text: {
+        default: text('Content', 'Click me')
       },
       type: {
         default: select('Type', ['button', 'submit', 'reset'], 'button')
@@ -58,14 +58,14 @@ storiesOf('Button', module)
       logEvent
     },
     props: {
-      text: {
-        default: text('Content', 'Click me')
-      },
       fontSize: {
         default: number('Font size', 16, fontOptions)
       },
+      text: {
+        default: text('Content', 'Click me')
+      },
       padding: {
-        default: text('Padding (--emd-button-padding)', '1em 4em')
+        default: text('Padding', '1em 4em')
       },
       borderRadius: {
         default: text('Border radius', '1em')

--- a/packages/emd-basic-login/src/component/Login.stories.js
+++ b/packages/emd-basic-login/src/component/Login.stories.js
@@ -26,11 +26,11 @@ storiesOf('Login', module)
       logEvent
     },
     props: {
-      text: {
-        default: text('Title', 'Acesse Sua Conta')
-      },
       fontSize: {
         default: number('Font size', 16, fontOptions)
+      },
+      text: {
+        default: text('Title', 'Acesse Sua Conta')
       }
     },
     template: `
@@ -53,11 +53,11 @@ storiesOf('Login', module)
       logEvent
     },
     props: {
-      text: {
-        default: text('Title', 'Acesse Sua Conta')
-      },
       fontSize: {
         default: number('Font size', 16, fontOptions)
+      },
+      text: {
+        default: text('Title', 'Acesse Sua Conta')
       }
     },
     template: `

--- a/packages/emd-basic-money/README.md
+++ b/packages/emd-basic-money/README.md
@@ -1,0 +1,75 @@
+# Button
+
+Emerald Money UI component.
+
+## Usage
+
+```html
+<emd-money value="12680.9"></emd-money>
+
+<emd-money value="12680.9" hidevalue></emd-money>
+
+<emd-money value="12680.9" currency="EUR" hidepositivesign></emd-money>
+```
+
+## Attributes and Properties
+
+#### `value`
+
+Defines the numeric value to be displayed.
+
+- Type: Number
+- Attribute and property
+
+#### `currency`
+
+Defines the currency to be displayed. It can be `BRL`, `USD` or `EUR`.
+
+- Type: String
+- Attribute and property
+
+#### `hidevalue`
+
+Hides the value with a rectangle.
+
+- Type: Boolean
+- Attribute and property
+
+#### `hidepositivesign`
+
+Hides the positive sign before the value. The negative sign cannot be hidden.
+
+- Type: Boolean
+- Attribute and property
+
+## CSS Properties
+
+#### `--emd-money-positive-color`
+
+Defines the color of positive values.
+
+- Default: `inherit`
+
+#### `--emd-money-neutral-color`
+
+Defines the color of values equal to zero.
+
+- Default: `inherit`
+
+#### `--emd-money-negative-color`
+
+Defines the color of negative values.
+
+- Default: `inherit`
+
+#### `--emd-money-effect-color`
+
+Defines the color of the rectangle that hides the value.
+
+- Default: `currentColor`
+
+#### `--emd-money-effect-opacity`
+
+Defines the opacity of the rectangle that hides the value.
+
+- Default: `0.5`

--- a/packages/emd-basic-money/README.md
+++ b/packages/emd-basic-money/README.md
@@ -1,4 +1,4 @@
-# Button
+# Money
 
 Emerald Money UI component.
 
@@ -16,7 +16,7 @@ Emerald Money UI component.
 
 #### `value`
 
-Defines the numeric value to be displayed.
+Defines the numeric value to be displayed. The component uses `Intl.NumberFormat` API to round values.
 
 - Type: Number
 - Attribute and property

--- a/packages/emd-basic-money/src/component/Money.stories.js
+++ b/packages/emd-basic-money/src/component/Money.stories.js
@@ -1,0 +1,180 @@
+import { storiesOf } from '@storybook/vue';
+import { withKnobs, number, select, boolean, color } from '@storybook/addon-knobs';
+import readMe from '../../README.md';
+import '../index.js';
+
+const fontOptions = {
+  range: true,
+  min: 12,
+  max: 24,
+  step: 1
+};
+
+const opacityOptions = {
+  range: true,
+  min: 0,
+  max: 1,
+  step: 0.1
+};
+
+const getCustomStyle = (
+  fontSize,
+  positiveColor,
+  neutralColor,
+  negativeColor,
+  effectColor,
+  effectOpacity
+) => ({
+  fontSize: `${fontSize}px`,
+  '--emd-money-positive-color': positiveColor,
+  '--emd-money-neutral-color': neutralColor,
+  '--emd-money-negative-color': negativeColor,
+  '--emd-money-effect-color': effectColor,
+  '--emd-money-effect-opacity': effectOpacity
+});
+
+storiesOf('Money', module)
+  .addDecorator(withKnobs)
+  .add('Default', () => ({
+    props: {
+      fontSize: {
+        default: number('Font size', 16, fontOptions)
+      },
+      value: {
+        default: number('Value', 1250)
+      },
+      currency: {
+        default: select('Currency', ['none', 'BRL', 'USD', 'EUR'], 'BRL')
+      },
+      showPositiveSign: {
+        default: boolean('Show Positive Sign', true)
+      },
+      showValue: {
+        default: boolean('Show Value', true)
+      }
+    },
+    template: `
+      <div :style="{ fontSize: fontSize + 'px' }">
+        <emd-money
+          :value="value"
+          :currency="currency"
+          :hidevalue="!showValue"
+          :hidepositivesign="!showPositiveSign"
+          style="display: block;"
+        >
+        </emd-money>
+      </div>
+    `
+  }), {
+    notes: { markdown: readMe }
+  })
+  .add('With Custom Style', () => ({
+    methods: {
+      getCustomStyle
+    },
+    props: {
+      fontSize: {
+        default: number('Font size', 16, fontOptions)
+      },
+      currency: {
+        default: select('Currency', ['none', 'BRL', 'USD', 'EUR'], 'BRL')
+      },
+      positiveColor: {
+        default: color('Positive color', '#14AA4B')
+      },
+      neutralColor: {
+        default: color('Neutral color', '#8B8B8B')
+      },
+      negativeColor: {
+        default: color('Negative color', '#E74C3C')
+      },
+      showPositiveSign: {
+        default: boolean('Show Positive Sign', true)
+      },
+      showValue: {
+        default: boolean('Show Value', true)
+      }
+    },
+    template: `
+      <div :style="getCustomStyle(fontSize, positiveColor, neutralColor, negativeColor, effectColor, effectOpacity)">
+        <emd-money
+          value="1250"
+          :currency="currency"
+          :hidevalue="!showValue"
+          :hidepositivesign="!showPositiveSign"
+          style="display: block; margin-bottom: 1em;"
+        >
+        </emd-money>
+        <emd-money
+          value="0"
+          :currency="currency"
+          :hidevalue="!showValue"
+          :hidepositivesign="!showPositiveSign"
+          style="display: block; margin-bottom: 1em;"
+        >
+        </emd-money>
+        <emd-money
+          value="-1250"
+          :currency="currency"
+          :hidevalue="!showValue"
+          :hidepositivesign="!showPositiveSign"
+          style="display: block;"
+        >
+        </emd-money>
+      </div>
+    `
+  }), {
+    notes: { markdown: readMe }
+  })
+  .add('With Hidden Value', () => ({
+    methods: {
+      getCustomStyle
+    },
+    props: {
+      fontSize: {
+        default: number('Font size', 16, fontOptions)
+      },
+      currency: {
+        default: select('Currency', ['none', 'BRL', 'USD', 'EUR'], 'BRL')
+      },
+      effectColor: {
+        default: color('Effect color', '#8B572A')
+      },
+      effectOpacity: {
+        default: number('Effect opacity', 0.5, opacityOptions)
+      },
+      showValue: {
+        default: boolean('Show Value', false)
+      }
+    },
+    template: `
+      <div :style="getCustomStyle(fontSize, positiveColor, neutralColor, negativeColor, effectColor, effectOpacity)">
+        <emd-money
+          value="1250"
+          :currency="currency"
+          :hidevalue="!showValue"
+          :hidepositivesign="!showPositiveSign"
+          style="display: block; margin-bottom: 1em;"
+        >
+        </emd-money>
+        <emd-money
+          value="0"
+          :currency="currency"
+          :hidevalue="!showValue"
+          :hidepositivesign="!showPositiveSign"
+          style="display: block; margin-bottom: 1em;"
+        >
+        </emd-money>
+        <emd-money
+          value="-1250"
+          :currency="currency"
+          :hidevalue="!showValue"
+          :hidepositivesign="!showPositiveSign"
+          style="display: block;"
+        >
+        </emd-money>
+      </div>
+    `
+  }), {
+    notes: { markdown: readMe }
+  });


### PR DESCRIPTION
## Description

Add README and Storybook for Money

![Screen Shot 2020-01-03 at 16 00 10](https://user-images.githubusercontent.com/125764/71743366-2401b680-2e43-11ea-86c3-e74727a16d12.png)

![Screen Shot 2020-01-03 at 16 00 14](https://user-images.githubusercontent.com/125764/71743367-2401b680-2e43-11ea-8d69-7f2ebd3bf7c5.png)

![Screen Shot 2020-01-03 at 16 00 19](https://user-images.githubusercontent.com/125764/71743368-2401b680-2e43-11ea-9626-ff8764aa15b9.png)

## Test

```
npm i && npm t
```

## Run Storybook

```
npm i && npm run storybook
```

## Run Locally

```
npm i && npm start emd-basic-money
```