### PR TITLE
Feature — Add code samples to Storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,11 @@
-import { configure } from '@storybook/vue';
+import { configure, addParameters } from '@storybook/vue';
 import './style.css';
+
+addParameters({
+  options: {
+    panelPosition: 'right'
+  },
+});
 
 const loadStories = () => {
   require('../packages/emd-basic-button/src/component/Button.stories.js');

--- a/.storybook/style.css
+++ b/.storybook/style.css
@@ -1,9 +1,9 @@
-@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i");
+@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i&Fira+Code&display=swap");
 
 html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  font-family: "Roboto", sans-serif;
+  font-family: "Open Sans", sans-serif;
   margin: 20px;
   font-size: 16px;
   background-color: #f2f5f7;
@@ -24,7 +24,15 @@ body {
 
 .codesample {
   padding: 20px;
-  background: turquoise;
-  border-radius: 8px;
+  background: rgba(30, 30, 30, 1);
+  color: rgba(156, 220, 254, 1);
+  border-radius: 10px;
   margin-bottom: auto;
+  overflow: auto;
+}
+
+.codesample pre {
+  margin: 0;
+  font-size: 14px;
+  font-family: 'Fira Code', monospace;
 }

--- a/.storybook/style.css
+++ b/.storybook/style.css
@@ -34,5 +34,5 @@ body {
 .codesample pre {
   margin: 0;
   font-size: 14px;
-  font-family: 'Fira Code', monospace;
+  font-family: "Fira Code", monospace;
 }

--- a/.storybook/style.css
+++ b/.storybook/style.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i");
+@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i");
 
 html {
   -webkit-font-smoothing: antialiased;
@@ -12,23 +12,19 @@ html {
 }
 
 body {
+  margin: 0;
+}
+
+.story {
   display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   grid-gap: 20px;
   margin: 0;
 }
 
-.fake-component {
-  width: 100%;
-  height: 200px;
-  background: repeating-linear-gradient(
-    45deg,
-    rgba(45, 56, 68, 0.075),
-    rgba(45, 56, 68, 0.075) 10px,
-    rgba(45, 56, 68, 0.15) 10px,
-    rgba(45, 56, 68, 0.15) 20px
-  );
-}
-
-h4, p {
-  margin: 0;
+.codesample {
+  padding: 20px;
+  background: turquoise;
+  border-radius: 8px;
+  margin-bottom: auto;
 }

--- a/packages/emd-basic-button/src/component/Button.stories.js
+++ b/packages/emd-basic-button/src/component/Button.stories.js
@@ -11,9 +11,57 @@ const fontOptions = {
   step: 1
 };
 
+const borderRadiusOptions = {
+  range: true,
+  min: 0,
+  max: 24,
+  step: 2
+};
+
 const logEvent = ({ type, detail }) => {
   action(type)(detail);
 };
+
+function getCodeSample () {
+  let attrs = '';
+  attrs += this.loading ? ' loading' : '';
+  attrs += this.disabled ? ' disabled' : '';
+  attrs += this.type ? ` type="${this.type}"` : '';
+  attrs += this.href ? ` href="${this.href}"` : '';
+  attrs += this.target ? ` target="${this.target}"` : '';
+
+  const hasCustomStyle = this.borderRadius ||
+    this.padding ||
+    this.color ||
+    this.backgroundColor ||
+    this.borderColor ||
+    this.disabledColor ||
+    this.disabledBackgroundColor ||
+    this.disabledBorderColor;
+
+  const styles = hasCustomStyle ? `<style>
+  emd-button {
+    font-size: ${this.fontSize}px;
+    border-radius: ${this.borderRadius}px;
+    --emd-button-padding: ${this.padding};
+    color: ${this.color};
+    background-color: ${this.backgroundColor};
+    border-color: ${this.borderColor};
+  }
+
+  emd-button[disabled] {
+    color: ${this.disabledColor};
+    background-color: ${this.disabledBackgroundColor};
+    border-color: ${this.disabledBorderColor};
+  }
+</style>
+
+` : '';
+
+  return `${styles}<emd-button${attrs}>
+  ${this.text}
+</emd-button>`;
+}
 
 storiesOf('Button', module)
   .addDecorator(withKnobs)
@@ -51,9 +99,13 @@ storiesOf('Button', module)
           </emd-button>
         </div>
         <div class="codesample">
+          <pre>{{ codesample }}</pre>
         </div>
       </div>
-    `
+    `,
+    computed: {
+      codesample: getCodeSample
+    }
   }), {
     notes: { markdown: readMe }
   })
@@ -65,14 +117,11 @@ storiesOf('Button', module)
       fontSize: {
         default: number('Font size', 16, fontOptions)
       },
-      text: {
-        default: text('Content', 'Click me')
+      borderRadius: {
+        default: number('Border radius', 10, borderRadiusOptions)
       },
       padding: {
         default: text('Padding', '1em 4em')
-      },
-      borderRadius: {
-        default: text('Border radius', '1em')
       },
       color: {
         default: color('Text color', '#fff')
@@ -87,10 +136,13 @@ storiesOf('Button', module)
         default: color('Disabled text color', '#fff')
       },
       disabledBackgroundColor: {
-        default: color('Disabled background color', '#c3c8d2')
+        default: color('Disabled bg color', '#c3c8d2')
       },
       disabledBorderColor: {
         default: color('Disabled border color', '#c3c8d2')
+      },
+      text: {
+        default: text('Content', 'Click me')
       },
       type: {
         default: select('Type', ['button', 'submit', 'reset'], 'button')
@@ -103,20 +155,21 @@ storiesOf('Button', module)
       }
     },
     computed: {
+      codesample: getCodeSample,
       customStyle () {
         return !this.disabled
           ? {
             color: this.color,
             backgroundColor: this.backgroundColor,
             borderColor: this.borderColor,
-            borderRadius: this.borderRadius,
+            borderRadius: this.borderRadius + 'px',
             '--emd-button-padding': this.padding
           }
           : {
             color: this.disabledColor,
             backgroundColor: this.disabledBackgroundColor,
             borderColor: this.disabledBorderColor,
-            borderRadius: this.borderRadius,
+            borderRadius: this.borderRadius + 'px',
             '--emd-button-padding': this.padding
           };
       }
@@ -138,6 +191,7 @@ storiesOf('Button', module)
           </emd-button>
         </div>
         <div class="codesample">
+          <pre>{{ codesample }}</pre>
         </div>
       </div>
     `
@@ -170,13 +224,20 @@ storiesOf('Button', module)
             :target="target"
             @click="logEvent"
           >
-            Go to {{ href }}
+            {{ text }}
           </emd-button>
         </div>
         <div class="codesample">
+          <pre>{{ codesample }}</pre>
         </div>
       </div>
-    `
+    `,
+    computed: {
+      text () {
+        return `Go to ${this.href}`;
+      },
+      codesample: getCodeSample
+    }
   }), {
     notes: { markdown: readMe }
   })
@@ -230,9 +291,21 @@ storiesOf('Button', module)
           </p>
         </div>
         <div class="codesample">
+          <pre>{{ codesample }}</pre>
         </div>
       </div>
-    `
+    `,
+    computed: {
+      codesample () {
+        return `<emd-button>
+  Multiple clicks (disabled)
+</emd-button>
+
+<emd-button multipleclicks>
+  Multiple clicks (enabled)
+</emd-button>`;
+      }
+    }
   }), {
     notes: { markdown: readMe }
   });

--- a/packages/emd-basic-button/src/component/Button.stories.js
+++ b/packages/emd-basic-button/src/component/Button.stories.js
@@ -24,9 +24,9 @@ const logEvent = ({ type, detail }) => {
 
 function getCodeSample () {
   let attrs = '';
-  attrs += this.loading ? ' loading' : '';
-  attrs += this.disabled ? ' disabled' : '';
   attrs += this.type ? ` type="${this.type}"` : '';
+  attrs += this.disabled ? ' disabled' : '';
+  attrs += this.loading ? ' loading' : '';
   attrs += this.href ? ` href="${this.href}"` : '';
   attrs += this.target ? ` target="${this.target}"` : '';
 

--- a/packages/emd-basic-button/src/component/Button.stories.js
+++ b/packages/emd-basic-button/src/component/Button.stories.js
@@ -39,15 +39,19 @@ storiesOf('Button', module)
       }
     },
     template: `
-      <div :style="{ fontSize: fontSize + 'px' }">
-        <emd-button
-          :type="type"
-          :disabled.prop="disabled"
-          :loading.prop="loading"
-          @click="logEvent"
-        >
-          {{ text }}
-        </emd-button>
+      <div class="story" :style="{ fontSize: fontSize + 'px' }">
+        <div class="component">
+          <emd-button
+            :type="type"
+            :disabled.prop="disabled"
+            :loading.prop="loading"
+            @click="logEvent"
+          >
+            {{ text }}
+          </emd-button>
+        </div>
+        <div class="codesample">
+        </div>
       </div>
     `
   }), {
@@ -119,17 +123,22 @@ storiesOf('Button', module)
     },
     template: `
       <div
+        class="story"
         :style="{ fontSize: fontSize + 'px' }"
       >
-        <emd-button
-          :style="customStyle"
-          :type="type"
-          :disabled.prop="disabled"
-          :loading.prop="loading"
-          @click="logEvent"
-        >
-          {{ text }}
-        </emd-button>
+        <div class="component">
+          <emd-button
+            :style="customStyle"
+            :type="type"
+            :disabled.prop="disabled"
+            :loading.prop="loading"
+            @click="logEvent"
+          >
+            {{ text }}
+          </emd-button>
+        </div>
+        <div class="codesample">
+        </div>
       </div>
     `
   }), {
@@ -152,15 +161,20 @@ storiesOf('Button', module)
     },
     template: `
       <div
+        class="story"
         :style="{ fontSize: fontSize + 'px' }"
       >
-        <emd-button
-          :href="href"
-          :target="target"
-          @click="logEvent"
-        >
-          Go to {{ href }}
-        </emd-button>
+        <div class="component">
+          <emd-button
+            :href="href"
+            :target="target"
+            @click="logEvent"
+          >
+            Go to {{ href }}
+          </emd-button>
+        </div>
+        <div class="codesample">
+        </div>
       </div>
     `
   }), {
@@ -190,26 +204,33 @@ storiesOf('Button', module)
     },
     template: `
       <div
-        style="display: grid; grid-gap: 1em; grid-template-columns: 1fr 1fr; align-items: center; max-width: 37.5em;"
+        class="story"
         :style="{ fontSize: fontSize + 'px' }"
       >
-        <emd-button
-          @click="addCountSlow"
+        <div
+          class="component"
+          style="display: grid; grid-gap: 1em; grid-template-columns: 1fr 1fr; align-items: center; max-width: 37.5em;"
         >
-          Multiple clicks (disabled)
-        </emd-button>
-        <p>
-          Click count: {{ slow }}
-        </p>
-        <emd-button
-          @click="addCountFast"
-          multipleclicks
-        >
-          Multiple clicks (enabled)
-        </emd-button>
-        <p>
-          Click count: {{ fast }}
-        </p>
+          <emd-button
+            @click="addCountSlow"
+          >
+            Multiple clicks (disabled)
+          </emd-button>
+          <p>
+            Click count: {{ slow }}
+          </p>
+          <emd-button
+            @click="addCountFast"
+            multipleclicks
+          >
+            Multiple clicks (enabled)
+          </emd-button>
+          <p>
+            Click count: {{ fast }}
+          </p>
+        </div>
+        <div class="codesample">
+        </div>
       </div>
     `
   }), {

--- a/packages/emd-basic-card/src/component/Card.stories.js
+++ b/packages/emd-basic-card/src/component/Card.stories.js
@@ -241,7 +241,7 @@ storiesOf('Card', module)
         default: boolean('Show footer', true)
       },
       expandedBody: {
-        default: boolean('Expande body', true)
+        default: boolean('Expand body', true)
       },
       useScroll: {
         default: true
@@ -303,7 +303,7 @@ storiesOf('Card', module)
         default: true
       },
       expandedBody: {
-        default: boolean('Expande body', true)
+        default: boolean('Expand body', true)
       },
       useScroll: {
         default: true
@@ -344,10 +344,10 @@ storiesOf('Card', module)
         default: true
       },
       expandedBody: {
-        default: boolean('Expande body', true)
+        default: boolean('Expand body', true)
       },
       useScroll: {
-        default: boolean('Scroll enabled', true)
+        default: boolean('Enable scroll', true)
       },
       fixedHeight: {
         default: '21em'

--- a/packages/emd-basic-card/src/component/Card.stories.js
+++ b/packages/emd-basic-card/src/component/Card.stories.js
@@ -241,7 +241,7 @@ storiesOf('Card', module)
         default: boolean('Show footer', true)
       },
       expandedBody: {
-        default: boolean('Expanded body', true)
+        default: boolean('Expande body', true)
       },
       useScroll: {
         default: true
@@ -303,7 +303,7 @@ storiesOf('Card', module)
         default: true
       },
       expandedBody: {
-        default: boolean('Expanded body', true)
+        default: boolean('Expande body', true)
       },
       useScroll: {
         default: true
@@ -344,7 +344,7 @@ storiesOf('Card', module)
         default: true
       },
       expandedBody: {
-        default: boolean('Expanded body', true)
+        default: boolean('Expande body', true)
       },
       useScroll: {
         default: boolean('Scroll enabled', true)

--- a/packages/emd-basic-card/src/component/Card.stories.js
+++ b/packages/emd-basic-card/src/component/Card.stories.js
@@ -11,135 +11,139 @@ const fontOptions = {
 };
 
 const template = `
-  <div :style="{ fontSize: fontSize + 'px', maxWidth: '600px' }">
-    <emd-card
-      :noscroll.prop="!useScroll"
-      :expandedbody.prop="expandedBody"
-      :style="{ '--emd-card-header-background': headerBackground, '--emd-card-footer-background': footerBackground, '--emd-card-body-background': bodyBackground, height: fixedHeight || 'auto' }"
-    >
-      <h4
-        v-if="showHeader"
-        slot="header"
-        :style="{ fontSize: '1.5em', color: headerColor || 'inherit' }"
+  <div class="story" :style="{ fontSize: fontSize + 'px' }">
+    <div class="component">
+      <emd-card
+        :noscroll.prop="!useScroll"
+        :expandedbody.prop="expandedBody"
+        :style="{ '--emd-card-header-background': headerBackground, '--emd-card-footer-background': footerBackground, '--emd-card-body-background': bodyBackground, height: fixedHeight || 'auto' }"
       >
-        {{ headerText }}
-      </h4>
-      <svg
-        v-if="showHeaderExtra"
-        slot="header-extra"
-        style="{ height: '1.5em' }"
-        xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"
-      >
-        <path :style="{ fill: headerColor || 'inherit' }" d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"/>
-      </svg>
-      <p
-        v-if="showFooter"
-        slot="footer"
-        :style="{ fontSize: '0.875em', margin: 'auto', color: footerColor || 'inherit' }"
-      >
-        <em>{{ footerText }}</em>
-      </p>
-      <table :style="{ width: '100%', borderCollapse: 'collapse' }">
-        <tbody>
-          <tr>
-            <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
-              January
-            </td>
-            <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
-              R$ 35.000,00
-            </td>
-          </tr>
-          <tr>
-            <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
-              February
-            </td>
-            <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
-              R$ 38.000,00
-            </td>
-          </tr>
-          <tr>
-            <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
-              March
-            </td>
-            <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
-              R$ 42.000,00
-            </td>
-          </tr>
-          <tr>
-            <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
-              April
-            </td>
-            <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
-              R$ 40.000,00
-            </td>
-          </tr>
-          <tr>
-            <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
-              May
-            </td>
-            <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
-              R$ 54.000,00
-            </td>
-          </tr>
-          <tr>
-            <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
-              June
-            </td>
-            <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
-              R$ 51.700,00
-            </td>
-          </tr>
-          <tr>
-            <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
-              July
-            </td>
-            <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
-              R$ 46.200,00
-            </td>
-          </tr>
-          <tr>
-            <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
-              August
-            </td>
-            <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
-              R$ 43.000,00
-            </td>
-          </tr>
-          <tr>
-            <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
-              September
-            </td>
-            <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
-              R$ 45.900,00
-            </td>
-          </tr>
-          <tr>
-            <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
-              October
-            </td>
-            <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
-              R$ 51.700,00
-            </td>
-          </tr>
-          <tr>
-            <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
-              November
-            </td>
-            <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
-              R$ 53.000,00
-            </td>
-          </tr>
-          <tr>
-            <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px' }">
-              December
-            </td>
-            <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0' }">
-              R$ 51.000,00
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </emd-card>
+        <h4
+          v-if="showHeader"
+          slot="header"
+          :style="{ fontSize: '1.5em', margin: 0, color: headerColor || 'inherit' }"
+        >
+          {{ headerText }}
+        </h4>
+        <svg
+          v-if="showHeaderExtra"
+          slot="header-extra"
+          style="{ height: '1.5em' }"
+          xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"
+        >
+          <path :style="{ fill: headerColor || 'inherit' }" d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"/>
+        </svg>
+        <p
+          v-if="showFooter"
+          slot="footer"
+          :style="{ fontSize: '0.875em', margin: 'auto', color: footerColor || 'inherit' }"
+        >
+          <em>{{ footerText }}</em>
+        </p>
+        <table :style="{ width: '100%', borderCollapse: 'collapse' }">
+          <tbody>
+            <tr>
+              <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
+                January
+              </td>
+              <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
+                R$ 35.000,00
+              </td>
+            </tr>
+            <tr>
+              <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
+                February
+              </td>
+              <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
+                R$ 38.000,00
+              </td>
+            </tr>
+            <tr>
+              <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
+                March
+              </td>
+              <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
+                R$ 42.000,00
+              </td>
+            </tr>
+            <tr>
+              <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
+                April
+              </td>
+              <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
+                R$ 40.000,00
+              </td>
+            </tr>
+            <tr>
+              <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
+                May
+              </td>
+              <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
+                R$ 54.000,00
+              </td>
+            </tr>
+            <tr>
+              <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
+                June
+              </td>
+              <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
+                R$ 51.700,00
+              </td>
+            </tr>
+            <tr>
+              <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
+                July
+              </td>
+              <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
+                R$ 46.200,00
+              </td>
+            </tr>
+            <tr>
+              <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
+                August
+              </td>
+              <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
+                R$ 43.000,00
+              </td>
+            </tr>
+            <tr>
+              <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
+                September
+              </td>
+              <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
+                R$ 45.900,00
+              </td>
+            </tr>
+            <tr>
+              <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
+                October
+              </td>
+              <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
+                R$ 51.700,00
+              </td>
+            </tr>
+            <tr>
+              <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px', borderBottom: '1px solid #ddd' }">
+                November
+              </td>
+              <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0', borderBottom: '1px solid #ddd' }">
+                R$ 53.000,00
+              </td>
+            </tr>
+            <tr>
+              <td :style="{ textAlign: 'left', padding: '0.75em 0 0.75em 20px' }">
+                December
+              </td>
+              <td :style="{ textAlign: 'right', padding: '0.75em 20px 0.75em 0' }">
+                R$ 51.000,00
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </emd-card>
+    </div>
+    <div class="codesample">
+    </div>
   </div>
 `;
 

--- a/packages/emd-basic-card/src/component/Card.stories.js
+++ b/packages/emd-basic-card/src/component/Card.stories.js
@@ -10,13 +10,77 @@ const fontOptions = {
   step: 1
 };
 
+const borderRadiusOptions = {
+  range: true,
+  min: 0,
+  max: 24,
+  step: 2
+};
+
+function getCodeSample () {
+  let attrs = '';
+  attrs += this.expandedBody ? ' expandedbody' : '';
+  attrs += !this.useScroll ? ' noscroll' : '';
+
+  const hasCustomStyle = this.borderRadius ||
+    this.headerColor ||
+    this.headerBackground ||
+    this.bodyBackground ||
+    this.footerColor ||
+    this.footerBackground;
+
+  const styles = hasCustomStyle ? `<style>
+  emd-card {
+    font-size: ${this.fontSize}px;
+    border-radius: ${this.borderRadius}px;
+    --emd-card-header-background: ${this.headerBackground};
+    --emd-card-body-background: ${this.bodyBackground};
+    --emd-card-footer-background: ${this.footerBackground};
+  }
+
+  emd-card h4,
+  emd-card emd-icon {
+    color: ${this.headerColor};
+  }
+
+  emd-card p {
+    color: ${this.footerColor};
+  }
+</style>
+
+` : '';
+
+  let slots = '';
+
+  slots += this.showHeader ? `
+  <h4 slot="header">
+    ${this.headerText}
+  </h4>` : '';
+
+  slots += this.showHeaderExtra ? `
+  <emd-icon
+    slot="header-extra"
+    icon="close"
+  ></emd-icon>` : '';
+
+  slots += this.showFooter ? `
+  <p slot="footer">
+    ${this.footerText}
+  </p>` : '';
+
+  return `${styles}<emd-card${attrs}>${slots}
+  <table>...</table>
+</emd-card>
+`;
+}
+
 const template = `
   <div class="story" :style="{ fontSize: fontSize + 'px' }">
     <div class="component">
       <emd-card
         :noscroll.prop="!useScroll"
         :expandedbody.prop="expandedBody"
-        :style="{ '--emd-card-header-background': headerBackground, '--emd-card-footer-background': footerBackground, '--emd-card-body-background': bodyBackground, height: fixedHeight || 'auto' }"
+        :style="{ borderRadius: borderRadius + 'px', '--emd-card-header-background': headerBackground, '--emd-card-footer-background': footerBackground, '--emd-card-body-background': bodyBackground, height: fixedHeight || 'auto' }"
       >
         <h4
           v-if="showHeader"
@@ -29,7 +93,7 @@ const template = `
           v-if="showHeaderExtra"
           slot="header-extra"
           style="{ height: '1.5em' }"
-          xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 18 18"
         >
           <path :style="{ fill: headerColor || 'inherit' }" d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"/>
         </svg>
@@ -143,6 +207,7 @@ const template = `
       </emd-card>
     </div>
     <div class="codesample">
+      <pre>{{ codesample }}</pre>
     </div>
   </div>
 `;
@@ -160,20 +225,33 @@ storiesOf('Card', module)
       footerText: {
         default: text('Footer text', 'Last updated on 31/12/2019')
       },
+      borderRadius: null,
+      headerColor: null,
+      headerBackground: null,
+      bodyBackground: null,
+      footerColor: null,
+      footerBackground: null,
       showHeader: {
         default: boolean('Show header', true)
       },
       showHeaderExtra: {
-        default: boolean('Show header extra', true)
+        default: boolean('Show icon', true)
       },
       showFooter: {
         default: boolean('Show footer', true)
       },
       expandedBody: {
         default: boolean('Expanded body', true)
-      }
+      },
+      useScroll: {
+        default: true
+      },
+      fixedHeight: null
     },
-    template
+    template,
+    computed: {
+      codesample: getCodeSample
+    }
   }), {
     notes: { markdown: readMe }
   })
@@ -187,6 +265,9 @@ storiesOf('Card', module)
       },
       footerText: {
         default: 'Last updated on 31/12/2019'
+      },
+      borderRadius: {
+        default: number('Border radius', 10, borderRadiusOptions)
       },
       headerColor: {
         default: color('Header text color', '#fff')
@@ -223,9 +304,16 @@ storiesOf('Card', module)
       },
       expandedBody: {
         default: boolean('Expanded body', true)
-      }
+      },
+      useScroll: {
+        default: true
+      },
+      fixedHeight: null
     },
-    template
+    template,
+    computed: {
+      codesample: getCodeSample
+    }
   }), {
     notes: { markdown: readMe }
   })
@@ -240,6 +328,12 @@ storiesOf('Card', module)
       footerText: {
         default: 'Last updated on 31/12/2019'
       },
+      borderRadius: null,
+      headerColor: null,
+      headerBackground: null,
+      bodyBackground: null,
+      footerColor: null,
+      footerBackground: null,
       showHeader: {
         default: true
       },
@@ -259,7 +353,10 @@ storiesOf('Card', module)
         default: '21em'
       }
     },
-    template
+    template,
+    computed: {
+      codesample: getCodeSample
+    }
   }), {
     notes: { markdown: readMe }
   });

--- a/packages/emd-basic-login/src/component/Login.stories.js
+++ b/packages/emd-basic-login/src/component/Login.stories.js
@@ -34,16 +34,24 @@ storiesOf('Login', module)
       }
     },
     template: `
-      <emd-login
+      <div
+        class="story"
         :style="{ fontSize: fontSize + 'px' }"
-        @forgotemail="logEvent"
-        @forgotpassword="logEvent"
-        @emailsubmitsuccess="logEvent"
-        @passwordsubmitsuccess="logEvent"
-        @keydown.stop=""
       >
-        {{ text }}
-      </emd-login>
+        <div class="component">
+          <emd-login
+            @forgotemail="logEvent"
+            @forgotpassword="logEvent"
+            @emailsubmitsuccess="logEvent"
+            @passwordsubmitsuccess="logEvent"
+            @keydown.stop=""
+          >
+            {{ text }}
+          </emd-login>
+        </div>
+        <div class="codesample">
+        </div>
+      </div>
     `
   }), {
     notes: { markdown: readMe }
@@ -61,18 +69,27 @@ storiesOf('Login', module)
       }
     },
     template: `
-      <emd-login
+      <div
+        class="story"
         :style="{ fontSize: fontSize + 'px' }"
-        email="user@stone.com.br"
-        step="2"
-        @forgotemail="logEvent"
-        @forgotpassword="logEvent"
-        @emailsubmitsuccess="logEvent"
-        @passwordsubmitsuccess="logEvent"
-        @keydown.stop=""
       >
-        {{ text }}
-      </emd-login>
+        <div class="component">
+          <emd-login
+            :style="{ fontSize: fontSize + 'px' }"
+            email="user@stone.com.br"
+            step="2"
+            @forgotemail="logEvent"
+            @forgotpassword="logEvent"
+            @emailsubmitsuccess="logEvent"
+            @passwordsubmitsuccess="logEvent"
+            @keydown.stop=""
+          >
+            {{ text }}
+          </emd-login>
+        </div>
+        <div class="codesample">
+        </div>
+      </div>
     `
   }), {
     notes: { markdown: readMe }

--- a/packages/emd-basic-login/src/component/Login.stories.js
+++ b/packages/emd-basic-login/src/component/Login.stories.js
@@ -21,7 +21,7 @@ const logEvent = ({ type, detail, target }) => {
 
 storiesOf('Login', module)
   .addDecorator(withKnobs)
-  .add('E-mail', () => ({
+  .add('Default', () => ({
     methods: {
       logEvent
     },
@@ -50,13 +50,21 @@ storiesOf('Login', module)
           </emd-login>
         </div>
         <div class="codesample">
+          <pre>{{ codesample }}</pre>
         </div>
       </div>
-    `
+    `,
+    computed: {
+      codesample () {
+        return `<emd-login>
+  ${this.text}
+</emd-login>`;
+      }
+    }
   }), {
     notes: { markdown: readMe }
   })
-  .add('Password', () => ({
+  .add('With password', () => ({
     methods: {
       logEvent
     },
@@ -88,9 +96,17 @@ storiesOf('Login', module)
           </emd-login>
         </div>
         <div class="codesample">
+          <pre>{{ codesample }}</pre>
         </div>
       </div>
-    `
+    `,
+    computed: {
+      codesample () {
+        return `<emd-login step="2" email="user@stone.com.br">
+  ${this.text}
+</emd-login>`;
+      }
+    }
   }), {
     notes: { markdown: readMe }
   });

--- a/packages/emd-basic-money/src/component/Money.stories.js
+++ b/packages/emd-basic-money/src/component/Money.stories.js
@@ -54,15 +54,22 @@ storiesOf('Money', module)
       }
     },
     template: `
-      <div :style="{ fontSize: fontSize + 'px' }">
-        <emd-money
-          :value="value"
-          :currency="currency"
-          :hidevalue="!showValue"
-          :hidepositivesign="!showPositiveSign"
-          style="display: block;"
-        >
-        </emd-money>
+      <div
+        class="story"
+        :style="{ fontSize: fontSize + 'px' }"
+      >
+        <div class="component">
+          <emd-money
+            :value="value"
+            :currency="currency"
+            :hidevalue="!showValue"
+            :hidepositivesign="!showPositiveSign"
+            style="display: block;"
+          >
+          </emd-money>
+        </div>
+        <div class="codesample">
+        </div>
       </div>
     `
   }), {
@@ -96,31 +103,38 @@ storiesOf('Money', module)
       }
     },
     template: `
-      <div :style="getCustomStyle(fontSize, positiveColor, neutralColor, negativeColor, effectColor, effectOpacity)">
-        <emd-money
-          value="1250"
-          :currency="currency"
-          :hidevalue="!showValue"
-          :hidepositivesign="!showPositiveSign"
-          style="display: block; margin-bottom: 1em;"
-        >
-        </emd-money>
-        <emd-money
-          value="0"
-          :currency="currency"
-          :hidevalue="!showValue"
-          :hidepositivesign="!showPositiveSign"
-          style="display: block; margin-bottom: 1em;"
-        >
-        </emd-money>
-        <emd-money
-          value="-1250"
-          :currency="currency"
-          :hidevalue="!showValue"
-          :hidepositivesign="!showPositiveSign"
-          style="display: block;"
-        >
-        </emd-money>
+      <div
+        class="story"
+        :style="getCustomStyle(fontSize, positiveColor, neutralColor, negativeColor, effectColor, effectOpacity)"
+      >
+        <div class="component">
+          <emd-money
+            value="1250"
+            :currency="currency"
+            :hidevalue="!showValue"
+            :hidepositivesign="!showPositiveSign"
+            style="display: block; margin-bottom: 1em;"
+          >
+          </emd-money>
+          <emd-money
+            value="0"
+            :currency="currency"
+            :hidevalue="!showValue"
+            :hidepositivesign="!showPositiveSign"
+            style="display: block; margin-bottom: 1em;"
+          >
+          </emd-money>
+          <emd-money
+            value="-1250"
+            :currency="currency"
+            :hidevalue="!showValue"
+            :hidepositivesign="!showPositiveSign"
+            style="display: block;"
+          >
+          </emd-money>
+        </div>
+        <div class="codesample">
+        </div>
       </div>
     `
   }), {
@@ -148,31 +162,38 @@ storiesOf('Money', module)
       }
     },
     template: `
-      <div :style="getCustomStyle(fontSize, positiveColor, neutralColor, negativeColor, effectColor, effectOpacity)">
-        <emd-money
-          value="1250"
-          :currency="currency"
-          :hidevalue="!showValue"
-          :hidepositivesign="!showPositiveSign"
-          style="display: block; margin-bottom: 1em;"
-        >
-        </emd-money>
-        <emd-money
-          value="0"
-          :currency="currency"
-          :hidevalue="!showValue"
-          :hidepositivesign="!showPositiveSign"
-          style="display: block; margin-bottom: 1em;"
-        >
-        </emd-money>
-        <emd-money
-          value="-1250"
-          :currency="currency"
-          :hidevalue="!showValue"
-          :hidepositivesign="!showPositiveSign"
-          style="display: block;"
-        >
-        </emd-money>
+      <div
+        class="story"
+        :style="getCustomStyle(fontSize, positiveColor, neutralColor, negativeColor, effectColor, effectOpacity)"
+      >
+        <div class="component">
+          <emd-money
+            value="1250"
+            :currency="currency"
+            :hidevalue="!showValue"
+            :hidepositivesign="!showPositiveSign"
+            style="display: block; margin-bottom: 1em;"
+          >
+          </emd-money>
+          <emd-money
+            value="0"
+            :currency="currency"
+            :hidevalue="!showValue"
+            :hidepositivesign="!showPositiveSign"
+            style="display: block; margin-bottom: 1em;"
+          >
+          </emd-money>
+          <emd-money
+            value="-1250"
+            :currency="currency"
+            :hidevalue="!showValue"
+            :hidepositivesign="!showPositiveSign"
+            style="display: block;"
+          >
+          </emd-money>
+        </div>
+        <div class="codesample">
+        </div>
       </div>
     `
   }), {

--- a/packages/emd-basic-money/src/component/Money.stories.js
+++ b/packages/emd-basic-money/src/component/Money.stories.js
@@ -17,21 +17,61 @@ const opacityOptions = {
   step: 0.1
 };
 
-const getCustomStyle = (
-  fontSize,
-  positiveColor,
-  neutralColor,
-  negativeColor,
-  effectColor,
-  effectOpacity
-) => ({
-  fontSize: `${fontSize}px`,
-  '--emd-money-positive-color': positiveColor,
-  '--emd-money-neutral-color': neutralColor,
-  '--emd-money-negative-color': negativeColor,
-  '--emd-money-effect-color': effectColor,
-  '--emd-money-effect-opacity': effectOpacity
-});
+function getCustomStyle () {
+  return {
+    'font-size': `${this.fontSize}px`,
+    '--emd-money-positive-color': this.positiveColor,
+    '--emd-money-neutral-color': this.neutralColor,
+    '--emd-money-negative-color': this.negativeColor,
+    '--emd-money-effect-color': this.effectColor,
+    '--emd-money-effect-opacity': this.effectOpacity
+  };
+}
+
+function getCodeSampleArgs (forcedValue) {
+  const value = this.value || forcedValue;
+
+  let args = '';
+
+  args += value != null ? `\n  value="${value}"` : '';
+
+  args += this.currency != null && this.currency !== 'none'
+    ? `\n  currency="${this.currency}"`
+    : '';
+
+  args += this.showPositiveSign === false ? '\n  hidepositivesign' : '';
+  args += this.showValue === false ? '\n  hidevalue' : '';
+
+  return args;
+}
+
+function getCodeSample () {
+  const hasCustomStyle = this.positiveColor ||
+    this.neutralColor ||
+    this.negativeColor ||
+    this.effectColor ||
+    this.effectOpacity;
+
+  const styleList = Object.entries(getCustomStyle.apply(this))
+    .map(([key, value]) => value ? `\n  ${key}: ${value};` : undefined)
+    .filter(result => result != null)
+    .join('');
+
+  const styles = `<style>${styleList}\n</style>\n\n`;
+  const boundGetCodeSampleArgs = getCodeSampleArgs.bind(this);
+
+  return `${hasCustomStyle ? styles : ''}${this.value
+    ? `<emd-money${boundGetCodeSampleArgs()}
+></emd-money>`
+    : `<emd-money${boundGetCodeSampleArgs(1250)}
+></emd-money>
+
+<emd-money${boundGetCodeSampleArgs(0)}
+></emd-money>
+
+<emd-money${boundGetCodeSampleArgs(-1250)}
+></emd-money>`}`;
+}
 
 storiesOf('Money', module)
   .addDecorator(withKnobs)
@@ -69,16 +109,17 @@ storiesOf('Money', module)
           </emd-money>
         </div>
         <div class="codesample">
+          <pre>{{ codesample }}</pre>
         </div>
       </div>
-    `
+    `,
+    computed: {
+      codesample: getCodeSample
+    }
   }), {
     notes: { markdown: readMe }
   })
   .add('With Custom Style', () => ({
-    methods: {
-      getCustomStyle
-    },
     props: {
       fontSize: {
         default: number('Font size', 16, fontOptions)
@@ -105,7 +146,7 @@ storiesOf('Money', module)
     template: `
       <div
         class="story"
-        :style="getCustomStyle(fontSize, positiveColor, neutralColor, negativeColor, effectColor, effectOpacity)"
+        :style="customStyle"
       >
         <div class="component">
           <emd-money
@@ -134,16 +175,18 @@ storiesOf('Money', module)
           </emd-money>
         </div>
         <div class="codesample">
+          <pre>{{ codesample }}</pre>
         </div>
       </div>
-    `
+    `,
+    computed: {
+      customStyle: getCustomStyle,
+      codesample: getCodeSample
+    }
   }), {
     notes: { markdown: readMe }
   })
   .add('With Hidden Value', () => ({
-    methods: {
-      getCustomStyle
-    },
     props: {
       fontSize: {
         default: number('Font size', 16, fontOptions)
@@ -164,14 +207,13 @@ storiesOf('Money', module)
     template: `
       <div
         class="story"
-        :style="getCustomStyle(fontSize, positiveColor, neutralColor, negativeColor, effectColor, effectOpacity)"
+        :style="customStyle"
       >
         <div class="component">
           <emd-money
             value="1250"
             :currency="currency"
             :hidevalue="!showValue"
-            :hidepositivesign="!showPositiveSign"
             style="display: block; margin-bottom: 1em;"
           >
           </emd-money>
@@ -179,7 +221,6 @@ storiesOf('Money', module)
             value="0"
             :currency="currency"
             :hidevalue="!showValue"
-            :hidepositivesign="!showPositiveSign"
             style="display: block; margin-bottom: 1em;"
           >
           </emd-money>
@@ -187,15 +228,19 @@ storiesOf('Money', module)
             value="-1250"
             :currency="currency"
             :hidevalue="!showValue"
-            :hidepositivesign="!showPositiveSign"
             style="display: block;"
           >
           </emd-money>
         </div>
         <div class="codesample">
+          <pre>{{ codesample }}</pre>
         </div>
       </div>
-    `
+    `,
+    computed: {
+      customStyle: getCustomStyle,
+      codesample: getCodeSample
+    }
   }), {
     notes: { markdown: readMe }
   });


### PR DESCRIPTION
## Description

Improve Storybook documentation by adding dynamic code samples next to the components.

<img width="1680" alt="Captura de Tela 2020-01-06 às 15 45 05" src="https://user-images.githubusercontent.com/125764/71850518-371abd80-30b3-11ea-90be-989615b12ef1.png">

<img width="1680" alt="Captura de Tela 2020-01-06 às 15 45 11" src="https://user-images.githubusercontent.com/125764/71850519-37b35400-30b3-11ea-9571-1ada67803a50.png">

<img width="1680" alt="Captura de Tela 2020-01-06 às 15 45 16" src="https://user-images.githubusercontent.com/125764/71850521-37b35400-30b3-11ea-945b-ff8aa23d69e3.png">

<img width="1680" alt="Captura de Tela 2020-01-06 às 15 45 20" src="https://user-images.githubusercontent.com/125764/71850522-37b35400-30b3-11ea-8160-3a130fccad96.png">

## Test

```
npm i && npm t
```

## Run Storybook

```
npm run storybook
```