### PR TITLE
Feature — nofallback property

### DIFF
--- a/packages/emd-basic-brand-icon/src/component/BrandIcon.css
+++ b/packages/emd-basic-brand-icon/src/component/BrandIcon.css
@@ -116,10 +116,6 @@
   fill: currentColor;
 }
 
-.emd-brand-icon__wrapper_unknown {
-  display: none;
-}
-
 /* for Edge compatibility */
 
 emd-brand-icon {

--- a/packages/emd-basic-brand-icon/src/component/BrandIcon.css
+++ b/packages/emd-basic-brand-icon/src/component/BrandIcon.css
@@ -116,6 +116,10 @@
   fill: currentColor;
 }
 
+.emd-brand-icon__wrapper_unknown {
+  display: none;
+}
+
 /* for Edge compatibility */
 
 emd-brand-icon {

--- a/packages/emd-basic-brand-icon/src/component/BrandIconController.js
+++ b/packages/emd-basic-brand-icon/src/component/BrandIconController.js
@@ -5,6 +5,24 @@ export const BrandIconController = (Base = class {}) => class extends Base {
       .replace(/-/g, '_')
       .replace(' ', '_')
       .toUpperCase();
-    return this.icons[key] || this.icons.STONE;
+    return this.icons[key] || '';
+  }
+
+  static get properties () {
+    return {
+      ...super.properties,
+      nofallback: {
+        type: Boolean,
+        reflect: true
+      }
+    };
+  }
+
+  get stoneIcon () {
+    return this.constructor.icons.STONE;
+  }
+
+  get isUnknownIcon () {
+    return this.nofallback && this.iconSvg === '';
   }
 };

--- a/packages/emd-basic-brand-icon/src/component/BrandIconView.js
+++ b/packages/emd-basic-brand-icon/src/component/BrandIconView.js
@@ -8,7 +8,6 @@ export const BrandIconView = ({
 }) => {
   let wrapperClass = 'emd-brand-icon__wrapper';
   wrapperClass += ` emd-brand-icon__wrapper_${icon}`;
-  wrapperClass += isUnknownIcon ? ' emd-brand-icon__wrapper_unknown' : '';
 
   return html`
     <style>

--- a/packages/emd-basic-brand-icon/src/component/BrandIconView.js
+++ b/packages/emd-basic-brand-icon/src/component/BrandIconView.js
@@ -5,16 +5,13 @@ export const BrandIconView = ({
   icon,
   stoneIcon,
   isUnknownIcon
-}) => {
-  let wrapperClass = 'emd-brand-icon__wrapper';
-  wrapperClass += ` emd-brand-icon__wrapper_${icon}`;
-
-  return html`
-    <style>
-      @import url("emd-basic-brand-icon/src/component/BrandIcon.css")
-    </style>
-    ${!isUnknownIcon ? html`
-      <div class="${wrapperClass}">${iconSvg || stoneIcon}</div>
-    ` : ''}
-  `;
-};
+}) => html`
+  <style>
+    @import url("emd-basic-brand-icon/src/component/BrandIcon.css")
+  </style>
+  ${!isUnknownIcon ? html`
+    <div class="emd-brand-icon__wrapper emd-brand-icon__wrapper_${icon}">
+      ${iconSvg || stoneIcon}
+    </div>
+  ` : ''}
+`;

--- a/packages/emd-basic-brand-icon/src/component/BrandIconView.js
+++ b/packages/emd-basic-brand-icon/src/component/BrandIconView.js
@@ -1,10 +1,21 @@
 import { html } from '@stone-payments/lit-element';
 
-export const BrandIconView = ({ iconSvg, icon }) => html`
-  <style>
-    @import url("emd-basic-brand-icon/src/component/BrandIcon.css")
-  </style>
-  <div class="emd-brand-icon__wrapper emd-brand-icon__wrapper_${icon}">
-    ${iconSvg}
-  </div>
-`;
+export const BrandIconView = ({
+  iconSvg,
+  icon,
+  stoneIcon,
+  isUnknownIcon
+}) => {
+  let wrapperClass = 'emd-brand-icon__wrapper';
+  wrapperClass += ` emd-brand-icon__wrapper_${icon}`;
+  wrapperClass += isUnknownIcon ? ' emd-brand-icon__wrapper_unknown' : '';
+
+  return html`
+    <style>
+      @import url("emd-basic-brand-icon/src/component/BrandIcon.css")
+    </style>
+    ${!isUnknownIcon ? html`
+      <div class="${wrapperClass}">${iconSvg || stoneIcon}</div>
+    ` : ''}
+  `;
+};


### PR DESCRIPTION
## Description

By default, unknown brands fallback to Stone. This PR adds a property called `nofallback` that makes the component display nothing instead.

## Test

```
npm i && npm t
```

## Run locally

```
npm i && npm start emd-basic-brand-icon
```