### PR TITLE
Fix sample HTML output

### DIFF
--- a/packages/emd-basic-icon/src/component/Icon.stories.js
+++ b/packages/emd-basic-icon/src/component/Icon.stories.js
@@ -19,7 +19,7 @@ const iconNames = Object
 
 function getCodeSample (iconName, color) {
   return `<emd-icon
-  icon="${iconName}${color ? `
+  icon="${iconName}"${color ? `
   style="color: ${color}"` : ''}
 ></emd-icon>`;
 }


### PR DESCRIPTION
## Description

Add missing `"` to HTML sample on Icon's Storybook.

### Before

<img width="899" alt="Captura de Tela 2020-03-11 às 16 11 32" src="https://user-images.githubusercontent.com/125764/76454492-87fcaa00-63b3-11ea-8c4d-b618cdcdc140.png">

### After

<img width="899" alt="Captura de Tela 2020-03-11 às 16 11 03" src="https://user-images.githubusercontent.com/125764/76454499-8b903100-63b3-11ea-9750-0a3f7d9c4025.png">

## Storybook

```
npm i && npm run storybook
```