### PR TITLE
Feature — Enhance Tooltip component (and fixes a bug)

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -13,6 +13,7 @@ const loadStories = () => {
   require('../packages/emd-basic-icon/src/component/Icon.stories.js');
   require('../packages/emd-basic-login/src/component/Login.stories.js');
   require('../packages/emd-basic-money/src/component/Money.stories.js');
+  require('../packages/emd-basic-tooltip/src/component/Tooltip.stories.js');
 }
 
 configure(loadStories, module);

--- a/packages/emd-basic-button/src/component/Button.stories.js
+++ b/packages/emd-basic-button/src/component/Button.stories.js
@@ -71,7 +71,7 @@ storiesOf('Button', module)
     },
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       text: {
         default: text('Content', 'Click me')
@@ -115,10 +115,10 @@ storiesOf('Button', module)
     },
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       borderRadius: {
-        default: number('Border radius', 10, borderRadiusOptions)
+        default: number('Border radius (px)', 10, borderRadiusOptions)
       },
       padding: {
         default: text('Padding', '1em 4em')
@@ -204,7 +204,7 @@ storiesOf('Button', module)
     },
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       href: {
         default: text('Href', 'http://stone.co')
@@ -260,7 +260,7 @@ storiesOf('Button', module)
     },
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       }
     },
     template: `

--- a/packages/emd-basic-card/src/component/Card.stories.js
+++ b/packages/emd-basic-card/src/component/Card.stories.js
@@ -217,7 +217,7 @@ storiesOf('Card', module)
   .add('Default', () => ({
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       headerText: {
         default: text('Header text', '2019 Sales')
@@ -258,7 +258,7 @@ storiesOf('Card', module)
   .add('With Custom Style', () => ({
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       headerText: {
         default: '2019 Sales'
@@ -267,7 +267,7 @@ storiesOf('Card', module)
         default: 'Last updated on 31/12/2019'
       },
       borderRadius: {
-        default: number('Border radius', 10, borderRadiusOptions)
+        default: number('Border radius (px)', 10, borderRadiusOptions)
       },
       headerColor: {
         default: color('Header text color', '#fff')
@@ -320,7 +320,7 @@ storiesOf('Card', module)
   .add('With Scroll', () => ({
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       headerText: {
         default: '2019 Sales'

--- a/packages/emd-basic-icon/src/component/Icon.stories.js
+++ b/packages/emd-basic-icon/src/component/Icon.stories.js
@@ -50,7 +50,7 @@ storiesOf('Icon', module)
     },
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       showCodeSamples: {
         default: boolean('Show code samples', true)
@@ -72,7 +72,7 @@ storiesOf('Icon', module)
     },
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       color: {
         default: color('Color', 'black')

--- a/packages/emd-basic-login/src/component/Login.stories.js
+++ b/packages/emd-basic-login/src/component/Login.stories.js
@@ -27,7 +27,7 @@ storiesOf('Login', module)
     },
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       text: {
         default: text('Title', 'Acesse Sua Conta')
@@ -70,7 +70,7 @@ storiesOf('Login', module)
     },
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       text: {
         default: text('Title', 'Acesse Sua Conta')

--- a/packages/emd-basic-money/src/component/Money.stories.js
+++ b/packages/emd-basic-money/src/component/Money.stories.js
@@ -82,7 +82,7 @@ storiesOf('Money', module)
   .add('Default', () => ({
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       value: {
         default: number('Value', 1250)
@@ -126,7 +126,7 @@ storiesOf('Money', module)
   .add('With Custom Style', () => ({
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       currency: {
         default: select('Currency', ['none', 'BRL', 'USD', 'EUR'], 'BRL')
@@ -193,7 +193,7 @@ storiesOf('Money', module)
   .add('With Hidden Value', () => ({
     props: {
       fontSize: {
-        default: number('Font size', 16, fontOptions)
+        default: number('Font size (px)', 16, fontOptions)
       },
       currency: {
         default: select('Currency', ['none', 'BRL', 'USD', 'EUR'], 'BRL')

--- a/packages/emd-basic-tooltip/README.md
+++ b/packages/emd-basic-tooltip/README.md
@@ -5,7 +5,7 @@ Emerald Tooltip UI component.
 ## Usage
 
 ```html
-<p id="target">120 members found</p>
+<span id="target">120 members found</span>
 <emd-tooltip for="target">79 online now</emd-tooltip>
 ```
 
@@ -30,6 +30,13 @@ The id of the target element. The tooltip **must be a sibling** of the target el
 The delay of the fade effect in milliseconds. Defaults to zero if unset.
 
 - Type: Number
+- Attribute and property
+
+#### `shadow`
+
+Shows the tooltip shadow. Defaults to `false`.
+
+- Type: Boolean
 - Attribute and property
 
 

--- a/packages/emd-basic-tooltip/README.md
+++ b/packages/emd-basic-tooltip/README.md
@@ -1,0 +1,84 @@
+# Tooltip
+
+Emerald Tooltip UI component.
+
+## Usage
+
+```html
+<p id="target">120 members found</p>
+<emd-tooltip for="target">79 online now</emd-tooltip>
+```
+
+## Attributes and Properties
+
+#### `position`
+
+The tooltip position relative to the target element. It can be `top`, `bottom`, `left` or `right`. Defaults to `right` if unset.
+
+- Type: String
+- Attribute and property
+
+#### `for`
+
+The id of the target element. The tooltip **must be a sibling** of the target element.
+
+- Type: String
+- Attribute and property
+
+#### `delay`
+
+The delay of the fade effect in milliseconds. Defaults to zero if unset.
+
+- Type: Number
+- Attribute and property
+
+
+## CSS Properties
+
+#### `--emd-tooltip-background-color`
+
+Defines the background color of the tooltip.
+
+- Default: `#0c1219`
+
+#### `--emd-tooltip-border-color`
+
+Defines the border color of the tooltip.
+
+- Default: `--emd-tooltip-background-color` or `#0c1219`
+
+#### `--emd-tooltip-border-radius`
+
+Defines the border radius of the tooltip.
+
+- Default: `6px`
+
+#### `--emd-tooltip-font-size`
+
+Defines the font size of the text.
+
+- Default: `0.75em`
+
+#### `--emd-tooltip-width`
+
+Defines the width of the tooltip.
+
+- Default: `max-content`
+
+#### `--emd-tooltip-padding`
+
+Defines the padding of the tooltip.
+
+- Default: `calc(0.75em - 2px)`
+
+#### `--emd-tooltip-text-align`
+
+Defines the text alignment.
+
+- Default: `left`
+
+#### `--emd-tooltip-text-color`
+
+Defines the text color.
+
+- Default: `#fff`

--- a/packages/emd-basic-tooltip/public/index.css
+++ b/packages/emd-basic-tooltip/public/index.css
@@ -12,9 +12,12 @@ html {
 }
 
 body {
+  display: grid;
+  grid-gap: 1em;
   text-align: center;
 }
 
 h2 {
-  display: inline-block;
+  display: block;
+  margin: auto;
 }

--- a/packages/emd-basic-tooltip/public/index.css
+++ b/packages/emd-basic-tooltip/public/index.css
@@ -12,8 +12,9 @@ html {
 }
 
 body {
-  display: grid;
-  grid-gap: 40px;
-  min-height: 600px;
   text-align: center;
+}
+
+h2 {
+  display: inline-block;
 }

--- a/packages/emd-basic-tooltip/public/index.html
+++ b/packages/emd-basic-tooltip/public/index.html
@@ -31,5 +31,12 @@
     text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eu tincidunt dui. Nulla risus felis, porta eu congue vitae, dignissim vel urna. Maecenas dictum magna a sollicitudin mattis.">
     Tooltip
   </emd-tooltip>
+
+  <h2 id="laser">Laser</h2>
+
+  <emd-tooltip
+    for="laser"
+    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eu tincidunt dui. Nulla risus felis, porta eu congue vitae, dignissim vel urna. Maecenas dictum magna a sollicitudin mattis.">
+  </emd-tooltip>
 </body>
 </html>

--- a/packages/emd-basic-tooltip/public/index.html
+++ b/packages/emd-basic-tooltip/public/index.html
@@ -8,35 +8,44 @@
   <link rel="stylesheet" href="./index.css">
 </head>
 <body>
-  <h1>Tooltip</h1>
-  <emd-tooltip 
-    position="left"
-    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eu tincidunt dui. Nulla risus felis, porta eu congue vitae, dignissim vel urna. Maecenas dictum magna a sollicitudin mattis.">
-    Tooltip
+  <h1>Tooltip&thinsp;—&thinsp;Using for attribute</h1>
+
+  <h2 id="title-top">Top</h2>
+  <emd-tooltip position="top" for="title-top">
+    Top it is
   </emd-tooltip>
 
-  <emd-tooltip 
-    position="top"
-    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eu tincidunt dui. Nulla risus felis, porta eu congue vitae, dignissim vel urna. Maecenas dictum magna a sollicitudin mattis.">
-    Tooltip
+  <h2 id="title-right">Right</h2>
+  <emd-tooltip position="right" for="title-right">
+    Right it is
   </emd-tooltip>
 
-  <emd-tooltip
-    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eu tincidunt dui. Nulla risus felis, porta eu congue vitae, dignissim vel urna. Maecenas dictum magna a sollicitudin mattis.">
-    Tooltip
+  <h2 id="title-left">Left</h2>
+  <emd-tooltip position="left" for="title-left">
+    Left it is
   </emd-tooltip>
 
-  <emd-tooltip
-    position="bottom"
-    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eu tincidunt dui. Nulla risus felis, porta eu congue vitae, dignissim vel urna. Maecenas dictum magna a sollicitudin mattis.">
-    Tooltip
+  <h2 id="title-bottom">Bottom</h2>
+  <emd-tooltip position="bottom" for="title-bottom">
+    Bottom it is
   </emd-tooltip>
 
-  <h2 id="laser">Laser</h2>
+  <h1>Tooltip&thinsp;—&thinsp;Legacy</h1>
 
-  <emd-tooltip
-    for="laser"
-    text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eu tincidunt dui. Nulla risus felis, porta eu congue vitae, dignissim vel urna. Maecenas dictum magna a sollicitudin mattis.">
+  <emd-tooltip position="top" text="Top it is">
+    <h2 id="title-top">Top</h2>
+  </emd-tooltip>
+
+  <emd-tooltip position="right" text="Right it is">
+    <h2>Right</h2>
+  </emd-tooltip>
+
+  <emd-tooltip position="left" text="Left it is">
+    <h2>Left</h2>
+  </emd-tooltip>
+
+  <emd-tooltip position="bottom" text="Bottom it is">
+    <h2>Bottom</h2>
   </emd-tooltip>
 </body>
 </html>

--- a/packages/emd-basic-tooltip/src/component/Tooltip.css
+++ b/packages/emd-basic-tooltip/src/component/Tooltip.css
@@ -39,6 +39,10 @@
   display: block;
 }
 
+.emd-tooltip__text_shadow {
+	box-shadow: 0px 4px 18px rgba(0, 0, 0, 0.1);
+}
+
 /* Right */
 
 .emd-tooltip__text_position_right {

--- a/packages/emd-basic-tooltip/src/component/Tooltip.css
+++ b/packages/emd-basic-tooltip/src/component/Tooltip.css
@@ -19,27 +19,15 @@
 /* Tooltip text */
 
 .emd-tooltip__text {
-  display: none;
   background-color: var(--emd-tooltip-background-color, #0c1219);
   color: var(--emd-tooltip-text-color, #fff);
-  padding: 0.75em;
-  border-radius: 6px;
+  padding: var(--emd-tooltip-padding, calc(0.75em - 2px));
+  border-radius: var(--emd-tooltip-border-radius, 6px);
   position: absolute;
   z-index: 1;
-  opacity: 0;
-  transition: opacity 1s;
   text-align: var(--emd-tooltip-text-align, left);
   font-size: var(--emd-tooltip-font-size, 0.75em);
   width: var(--emd-tooltip-min-width, var(--emd-tooltip-width, max-content));
-}
-
-/* Show the tooltip text on mouse over */
-
-.emd-tooltip__wrapper_legacy:hover .emd-tooltip__text,
-.emd-tooltip__wrapper_targeted.emd-tooltip__wrapper_active .emd-tooltip__text {
-  display: block;
-  opacity: 1;
-  white-space: normal;
 }
 
 /* Right */
@@ -176,6 +164,35 @@
 	border-bottom-color: var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, #0c1219));
 	border-width: 8px;
 	margin-left: -8px;
+}
+
+/* Show or hide */
+
+.emd-tooltip__wrapper_legacy .emd-tooltip__text,
+.emd-tooltip__wrapper_targeted .emd-tooltip__text {
+  transform: scale(0);
+  opacity: 0;
+  transition: opacity 0.36s ease-in-out, transform 0s 2s;
+}
+
+.emd-tooltip__wrapper_legacy:hover .emd-tooltip__text,
+.emd-tooltip__wrapper_targeted.emd-tooltip__wrapper_active .emd-tooltip__text {
+  opacity: 1;
+  transition: opacity 0.36s ease-in-out, transform 0s;
+}
+
+.emd-tooltip__wrapper_legacy:hover .emd-tooltip__text_position_right,
+.emd-tooltip__wrapper_targeted.emd-tooltip__wrapper_active .emd-tooltip__text_position_right,
+.emd-tooltip__wrapper_legacy:hover .emd-tooltip__text_position_left,
+.emd-tooltip__wrapper_targeted.emd-tooltip__wrapper_active .emd-tooltip__text_position_left {
+  transform: scale(1) translateY(-50%);
+}
+
+.emd-tooltip__wrapper_legacy:hover .emd-tooltip__text_position_top,
+.emd-tooltip__wrapper_targeted.emd-tooltip__wrapper_active .emd-tooltip__text_position_top,
+.emd-tooltip__wrapper_legacy:hover .emd-tooltip__text_position_bottom,
+.emd-tooltip__wrapper_targeted.emd-tooltip__wrapper_active .emd-tooltip__text_position_bottom {
+  transform: scale(1) translateX(-50%);
 }
 
 /* for Edge compatibility */

--- a/packages/emd-basic-tooltip/src/component/Tooltip.css
+++ b/packages/emd-basic-tooltip/src/component/Tooltip.css
@@ -17,10 +17,11 @@
 }
 
 /* Tooltip text */
+
 .emd-tooltip__text {
   display: none;
   background-color: var(--emd-tooltip-background-color, #0c1219);
-  color: #fff;
+  color: var(--emd-tooltip-text-color, #fff);
   padding: 0.75em;
   border-radius: 6px;
   position: absolute;
@@ -29,86 +30,151 @@
   transition: opacity 1s;
   text-align: var(--emd-tooltip-text-align, left);
   font-size: var(--emd-tooltip-font-size, 0.75em);
+  width: var(--emd-tooltip-min-width, var(--emd-tooltip-width, max-content));
 }
 
-/* Show the tooltip text when you mouse over the tooltip container */
+/* Show the tooltip text on mouse over */
+
 .emd-tooltip__wrapper:hover .emd-tooltip__text {
   display: block;
   opacity: 1;
   white-space: normal;
-  width: var(--emd-tooltip-min-width, max-content);
 }
+
+/* Right */
 
 .emd-tooltip__text_position_right {
   top: 50%;
   left: 100%;
   transform: translateY(-50%);
-  margin-left: 8px;
+  margin-left: 14px;
+  border: 1px solid var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, currentColor));
+}
+
+.emd-tooltip__text_position_right::after,
+.emd-tooltip__text_position_right::before {
+	right: 100%;
+	top: 50%;
+	border: solid transparent;
+	content: "";
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none;
 }
 
 .emd-tooltip__text_position_right::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  right: 100%; /* To the left of the tooltip__text_position_bottomtooltip */
-  border-width: 5px;
-  border-style: solid;
-  border-color: transparent #0c1219 transparent transparent;
+	border-right-color: var(--emd-tooltip-background-color, #0c1219);
+	border-width: 7px;
+	margin-top: -7px;
 }
+
+.emd-tooltip__text_position_right::before {
+	border-right-color: var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, currentColor));
+	border-width: 8px;
+	margin-top: -8px;
+}
+
+/* Left */
 
 .emd-tooltip__text_position_left {
   top: 50%;
-  transform: translateY(-50%);
   right: 100%;
-  margin-right: 8px;
+  transform: translateY(-50%);
+  margin-right: 14px;
+  border: 1px solid var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, currentColor));
+}
+
+.emd-tooltip__text_position_left::after,
+.emd-tooltip__text_position_left::before {
+	left: 100%;
+	top: 50%;
+	border: solid transparent;
+	content: "";
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none;
 }
 
 .emd-tooltip__text_position_left::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  left: 100%; /* To the right of the tooltip */
-  border-width: 5px;
-  border-style: solid;
-  border-color: transparent transparent transparent #0c1219;
+	border-left-color: var(--emd-tooltip-background-color, #0c1219);
+	border-width: 7px;
+	margin-top: -7px;
 }
+
+.emd-tooltip__text_position_left::before {
+	border-left-color: var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, currentColor));
+	border-width: 8px;
+	margin-top: -8px;
+}
+
+/* Top */
 
 .emd-tooltip__text_position_top {
   bottom: 100%;
-  margin-bottom: 8px;
   left: 50%;
   transform: translateX(-50%);
+  margin-bottom: 14px;
+  border: 1px solid var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, #0c1219));
+}
+
+.emd-tooltip__text_position_top::after,
+.emd-tooltip__text_position_top::before {
+	top: 100%;
+	left: 50%;
+	border: solid transparent;
+	content: "";
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none;
 }
 
 .emd-tooltip__text_position_top::after {
-  content: "";
-  position: absolute;
-  top: 100%; /* At the bottom of the tooltip */
-  left: 50%;
-  margin-left: -5px;
-  border-width: 5px;
-  border-style: solid;
-  border-color: #0c1219 transparent transparent transparent;
+	border-top-color: var(--emd-tooltip-background-color, #0c1219);
+	border-width: 7px;
+	margin-left: -7px;
 }
+
+.emd-tooltip__text_position_top::before {
+	border-top-color: var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, #0c1219));
+	border-width: 8px;
+	margin-left: -8px;
+}
+
+/* Bottom */
 
 .emd-tooltip__text_position_bottom {
   top: 100%;
-  margin-top: 8px;
   left: 50%;
-  transform: translateX(-50%)
+  transform: translateX(-50%);
+  margin-top: 14px;
+  border: 1px solid var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, #0c1219));
+}
+
+.emd-tooltip__text_position_bottom::after,
+.emd-tooltip__text_position_bottom::before {
+	bottom: 100%;
+	left: 50%;
+	border: solid transparent;
+	content: "";
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none;
 }
 
 .emd-tooltip__text_position_bottom::after {
-  content: "";
-  position: absolute;
-  bottom: 100%; /* At the top of the tooltip */
-  left: 50%;
-  margin-left: -5px;
-  border-width: 5px;
-  border-style: solid;
-  border-color: transparent transparent #0c1219 transparent;
+	border-bottom-color: var(--emd-tooltip-background-color, #0c1219);
+	border-width: 7px;
+	margin-left: -7px;
+}
+
+.emd-tooltip__text_position_bottom::before {
+	border-bottom-color: var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, #0c1219));
+	border-width: 8px;
+	margin-left: -8px;
 }
 
 /* for Edge compatibility */

--- a/packages/emd-basic-tooltip/src/component/Tooltip.css
+++ b/packages/emd-basic-tooltip/src/component/Tooltip.css
@@ -13,7 +13,8 @@
   left: 0;
   right: 0;
   bottom: 0;
-  margin: auto;
+	margin: auto;
+	pointer-events: none;
 }
 
 /* Tooltip text */
@@ -180,13 +181,13 @@
 .emd-tooltip__wrapper_targeted .emd-tooltip__text {
   transform: scale(0);
   opacity: 0;
-  transition: opacity 0.36s ease-in-out, transform 0s 2s;
+  transition: opacity var(--emd-tooltip-delay, 0s) ease-in-out, transform 0s var(--emd-tooltip-delay, 0s);
 }
 
 .emd-tooltip__wrapper_legacy:hover .emd-tooltip__text,
 .emd-tooltip__wrapper_targeted.emd-tooltip__wrapper_active .emd-tooltip__text {
   opacity: 1;
-  transition: opacity 0.36s ease-in-out, transform 0s;
+  transition: opacity var(--emd-tooltip-delay, 0s) ease-in-out, transform 0s;
 }
 
 .emd-tooltip__wrapper_legacy:hover .emd-tooltip__text_position_right,

--- a/packages/emd-basic-tooltip/src/component/Tooltip.css
+++ b/packages/emd-basic-tooltip/src/component/Tooltip.css
@@ -7,6 +7,15 @@
   display: inline-block;
 }
 
+.emd-tooltip__wrapper_targeted {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: auto;
+}
+
 /* Tooltip text */
 .emd-tooltip__text {
   display: none;
@@ -27,7 +36,7 @@
   display: block;
   opacity: 1;
   white-space: normal;
-  min-width: var(--emd-tooltip-min-width, max-content);
+  width: var(--emd-tooltip-min-width, max-content);
 }
 
 .emd-tooltip__text_position_right {
@@ -38,7 +47,7 @@
 }
 
 .emd-tooltip__text_position_right::after {
-  content: " ";
+  content: "";
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -56,7 +65,7 @@
 }
 
 .emd-tooltip__text_position_left::after {
-  content: " ";
+  content: "";
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -74,7 +83,7 @@
 }
 
 .emd-tooltip__text_position_top::after {
-  content: " ";
+  content: "";
   position: absolute;
   top: 100%; /* At the bottom of the tooltip */
   left: 50%;
@@ -92,7 +101,7 @@
 }
 
 .emd-tooltip__text_position_bottom::after {
-  content: " ";
+  content: "";
   position: absolute;
   bottom: 100%; /* At the top of the tooltip */
   left: 50%;

--- a/packages/emd-basic-tooltip/src/component/Tooltip.css
+++ b/packages/emd-basic-tooltip/src/component/Tooltip.css
@@ -49,7 +49,7 @@
   left: 100%;
   transform: translateY(-50%);
   margin-left: 14px;
-  border: 1px solid var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, currentColor));
+  border: 1px solid var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, #0c1219));
 }
 
 .emd-tooltip__text_position_right::after,
@@ -71,7 +71,7 @@
 }
 
 .emd-tooltip__text_position_right::before {
-	border-right-color: var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, currentColor));
+	border-right-color: var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, #0c1219));
 	border-width: 8px;
 	margin-top: -8px;
 }
@@ -83,7 +83,7 @@
   right: 100%;
   transform: translateY(-50%);
   margin-right: 14px;
-  border: 1px solid var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, currentColor));
+  border: 1px solid var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, #0c1219));
 }
 
 .emd-tooltip__text_position_left::after,
@@ -105,7 +105,7 @@
 }
 
 .emd-tooltip__text_position_left::before {
-	border-left-color: var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, currentColor));
+	border-left-color: var(--emd-tooltip-border-color, var(--emd-tooltip-background-color, #0c1219));
 	border-width: 8px;
 	margin-top: -8px;
 }

--- a/packages/emd-basic-tooltip/src/component/Tooltip.css
+++ b/packages/emd-basic-tooltip/src/component/Tooltip.css
@@ -19,15 +19,23 @@
 /* Tooltip text */
 
 .emd-tooltip__text {
+  position: absolute;
   background-color: var(--emd-tooltip-background-color, #0c1219);
   color: var(--emd-tooltip-text-color, #fff);
   padding: var(--emd-tooltip-padding, calc(0.75em - 2px));
   border-radius: var(--emd-tooltip-border-radius, 6px);
-  position: absolute;
-  z-index: 1;
   text-align: var(--emd-tooltip-text-align, left);
   font-size: var(--emd-tooltip-font-size, 0.75em);
   width: var(--emd-tooltip-min-width, var(--emd-tooltip-width, max-content));
+  z-index: 1;
+}
+
+.emd-tooltip__text {
+  display: none;
+}
+
+.emd-tooltip__text_ready {
+  display: block;
 }
 
 /* Right */

--- a/packages/emd-basic-tooltip/src/component/Tooltip.css
+++ b/packages/emd-basic-tooltip/src/component/Tooltip.css
@@ -35,7 +35,8 @@
 
 /* Show the tooltip text on mouse over */
 
-.emd-tooltip__wrapper:hover .emd-tooltip__text {
+.emd-tooltip__wrapper_legacy:hover .emd-tooltip__text,
+.emd-tooltip__wrapper_targeted.emd-tooltip__wrapper_active .emd-tooltip__text {
   display: block;
   opacity: 1;
   white-space: normal;

--- a/packages/emd-basic-tooltip/src/component/Tooltip.stories.js
+++ b/packages/emd-basic-tooltip/src/component/Tooltip.stories.js
@@ -1,0 +1,195 @@
+import { storiesOf } from '@storybook/vue';
+import { withKnobs, text, number, select, color, boolean } from '@storybook/addon-knobs';
+import readMe from '../../README.md';
+import '../index.js';
+
+const fontOptions = {
+  range: true,
+  min: 12,
+  max: 24,
+  step: 1
+};
+
+const borderRadiusOptions = {
+  range: true,
+  min: 0,
+  max: 24,
+  step: 2
+};
+
+const delayOptions = {
+  range: true,
+  min: 0,
+  max: 900,
+  step: 180
+};
+
+function getCodeSample () {
+  const hasCustomStyle = this.tooltipFontSize ||
+    this.tooltipTextAlign ||
+    this.tooltipBorderRadius ||
+    this.width ||
+    this.padding ||
+    this.textColor ||
+    this.backgroundColor ||
+    this.borderColor;
+
+  const styles = hasCustomStyle ? `<style>
+  emd-tooltip {
+    --emd-tooltip-font-size: ${this.tooltipFontSize};
+    --emd-tooltip-text-align: ${this.tooltipTextAlign};
+    --emd-tooltip-border-radius: ${this.tooltipBorderRadius}px;
+    --emd-tooltip-width: ${this.width};
+    --emd-tooltip-padding: ${this.padding};
+    --emd-tooltip-text-color: ${this.textColor};
+    --emd-tooltip-background-color: ${this.backgroundColor};
+    --emd-tooltip-border-color: ${this.borderColor};
+  }
+</style>
+
+` : '';
+
+  const position = this.position ? `\n  position="${this.position}"` : '';
+  const delay = this.delay ? `\n  delay="${this.delay}"` : '';
+  const shadow = this.shadow ? '\n  shadow' : '';
+
+  return `${styles}<span id="target">
+  Hover me
+</span>
+
+<emd-tooltip
+  for="target"${position}${delay}${shadow}
+>
+  ${this.text}
+</emd-tooltip>`;
+}
+
+storiesOf('Tooltip', module)
+  .addDecorator(withKnobs)
+  .add('Default', () => ({
+    props: {
+      fontSize: {
+        default: number('Font size (px)', 16, fontOptions)
+      },
+      text: {
+        default: text('Content', 'This is a tooltip')
+      },
+      position: {
+        default: select('Position', ['top', 'bottom', 'left', 'right'], 'right')
+      },
+      delay: {
+        default: number('Delay (ms)', 0, delayOptions)
+      },
+      shadow: {
+        default: boolean('Shadow', false)
+      }
+    },
+    template: `
+      <div class="story" :style="{ fontSize: fontSize + 'px' }">
+        <div class="component" style="text-align: center;">
+          <h2 id="title" style="display: inline-block; margin: 4em auto;">
+            Hover me
+          </h2>
+          <emd-tooltip
+            for="title"
+            :position="position"
+            :delay="delay"
+            :shadow.prop="shadow"
+          >
+            {{ text }}
+          </emd-tooltip>
+        </div>
+        <div class="codesample">
+          <pre>{{ codesample }}</pre>
+        </div>
+      </div>
+    `,
+    computed: {
+      codesample: getCodeSample
+    }
+  }), {
+    notes: { markdown: readMe }
+  })
+  .add('With Custom Styles', () => ({
+    props: {
+      fontSize: {
+        default: number('Font size (px)', 16, fontOptions)
+      },
+      tooltipFontSize: {
+        default: text('Tooltip font size (px)', '14px')
+      },
+      tooltipTextAlign: {
+        default: select('Tooltip text alignment',
+          ['left', 'center', 'right'], 'center')
+      },
+      tooltipBorderRadius: {
+        default: number('Border radius (px)', 6, borderRadiusOptions)
+      },
+      text: {
+        default: text('Content', 'This is a tooltip with custom style')
+      },
+      width: {
+        default: text('Width', '90px')
+      },
+      padding: {
+        default: text('Padding', '1em')
+      },
+      textColor: {
+        default: color('Text color', '#576069')
+      },
+      backgroundColor: {
+        default: color('Background color', '#fff')
+      },
+      borderColor: {
+        default: color('Border color', '#14AA4B')
+      },
+      position: {
+        default: select('Position',
+          ['top', 'bottom', 'left', 'right'], 'bottom')
+      },
+      delay: {
+        default: number('Delay (ms)', 360, delayOptions)
+      },
+      shadow: {
+        default: boolean('Shadow', false)
+      }
+    },
+    template: `
+      <div class="story" :style="{ fontSize: fontSize + 'px' }">
+        <div class="component" style="text-align: center;">
+          <h2 id="title" style="display: inline-block; margin: 4em auto;">
+            Hover me
+          </h2>
+          <emd-tooltip
+            for="title"
+            :style="customStyle"
+            :position="position"
+            :delay="delay"
+            :shadow.prop="shadow"
+          >
+            {{ text }}
+          </emd-tooltip>
+        </div>
+        <div class="codesample">
+          <pre>{{ codesample }}</pre>
+        </div>
+      </div>
+    `,
+    computed: {
+      codesample: getCodeSample,
+      customStyle () {
+        return {
+          '--emd-tooltip-font-size': this.tooltipFontSize,
+          '--emd-tooltip-text-align': this.tooltipTextAlign,
+          '--emd-tooltip-border-radius': `${this.tooltipBorderRadius}px`,
+          '--emd-tooltip-width': this.width,
+          '--emd-tooltip-padding': this.padding,
+          '--emd-tooltip-text-color': this.textColor,
+          '--emd-tooltip-background-color': this.backgroundColor,
+          '--emd-tooltip-border-color': this.borderColor
+        };
+      }
+    }
+  }), {
+    notes: { markdown: readMe }
+  });

--- a/packages/emd-basic-tooltip/src/component/TooltipController.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipController.js
@@ -25,6 +25,10 @@ export const TooltipController = (Base = class {}) =>
           type: String,
           reflect: true
         },
+        delay: {
+          type: Number,
+          reflect: true
+        },
         targetActive: {
           type: Boolean,
           reflect: false
@@ -40,14 +44,18 @@ export const TooltipController = (Base = class {}) =>
       super.attributeChangedCallback(attrName, pastValue, nextValue);
 
       if (attrName === 'for') {
-        this.unbindTooltipAndTarget();
+        this.removeTargetListeners();
 
-        const targetAttempt = this.parentNode && this.parentNode.children
+        this.target = this.parentNode && this.parentNode.children
           ? Array.from(this.parentNode.children).find(el => el.id === nextValue)
           : undefined;
 
-        this.target = targetAttempt;
-        this.bindTooltipAndTarget();
+        this.addTargetListeners();
+        this.updateTooltipPosition();
+      }
+
+      if (attrName === 'delay') {
+        this.style.setProperty('--emd-tooltip-delay', `${nextValue}ms`);
       }
     }
 
@@ -60,23 +68,21 @@ export const TooltipController = (Base = class {}) =>
 
     disconnectedCallback () {
       super.disconnectedCallback();
-      this.unbindTooltipAndTarget();
+      this.removeTargetListeners();
     }
 
-    unbindTooltipAndTarget () {
+    removeTargetListeners () {
       if (this.target) {
         this.target.removeEventListener('mouseover', this.handleMouseOver);
         this.target.removeEventListener('mouseout', this.handleMouseOut);
       }
     }
 
-    bindTooltipAndTarget () {
+    addTargetListeners () {
       if (this.target) {
         this.target.addEventListener('mouseover', this.handleMouseOver);
         this.target.addEventListener('mouseout', this.handleMouseOut);
       }
-
-      this.updateTooltipPosition();
     }
 
     updateTooltipPosition () {

--- a/packages/emd-basic-tooltip/src/component/TooltipController.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipController.js
@@ -30,9 +30,24 @@ export const TooltipController = (Base = class {}) =>
       this._for = value;
 
       if (this.target) {
-        console.log(this.target);
+        this._interval = window.requestAnimationFrame(() => {
+          const {
+            top,
+            left,
+            width,
+            height
+          } = this.target.getBoundingClientRect();
+
+          this.style.top = `${top}px`;
+          this.style.left = `${left}px`;
+          this.style.width = `${width}px`;
+          this.style.height = `${height}px`;
+          this.style.position = 'fixed';
+          this.style.margin = 'auto';
+        });
       } else {
-        console.log('removed target');
+        window.cancelAnimationFrame(this._interval);
+        this.removeAttribute('style');
       }
 
       this.requestUpdate('for', oldValue);

--- a/packages/emd-basic-tooltip/src/component/TooltipController.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipController.js
@@ -26,6 +26,10 @@ export const TooltipController = (Base = class {}) =>
           type: Number,
           reflect: true
         },
+        shadow: {
+          type: Boolean,
+          reflect: true
+        },
         targetActive: {
           type: Boolean,
           reflect: false

--- a/packages/emd-basic-tooltip/src/component/TooltipController.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipController.js
@@ -32,20 +32,23 @@ export const TooltipController = (Base = class {}) =>
       };
     }
 
-    get target () {
-      return this.for && this.parentNode && this.parentNode.children
-        ? Array.from(this.parentNode.children).find(el => el.id === this.for)
-        : undefined;
-    }
+    attributeChangedCallback (attrName, pastValue, nextValue) {
+      super.attributeChangedCallback(attrName, pastValue, nextValue);
 
-    attributeChangedCallback (...attrs) {
-      super.attributeChangedCallback(...attrs);
-      this.bindTooltipAndTarget();
+      if (attrName === 'for') {
+        this.unbindTooltipAndTarget();
+
+        const targetAttempt = this.parentNode && this.parentNode.children
+          ? Array.from(this.parentNode.children).find(el => el.id === nextValue)
+          : undefined;
+
+        this.target = targetAttempt;
+        this.bindTooltipAndTarget();
+      }
     }
 
     connectedCallback () {
       super.connectedCallback();
-      this.bindTooltipAndTarget();
     }
 
     disconnectedCallback () {
@@ -54,8 +57,6 @@ export const TooltipController = (Base = class {}) =>
     }
 
     unbindTooltipAndTarget () {
-      this.removeAttribute('style');
-
       if (this.target) {
         this.target.removeEventListener('mouseover', this.handleMouseOver);
         this.target.removeEventListener('mouseout', this.handleMouseOut);
@@ -63,8 +64,6 @@ export const TooltipController = (Base = class {}) =>
     }
 
     bindTooltipAndTarget () {
-      this.unbindTooltipAndTarget();
-
       if (this.target) {
         this.target.addEventListener('mouseover', this.handleMouseOver);
         this.target.addEventListener('mouseout', this.handleMouseOut);
@@ -89,23 +88,27 @@ export const TooltipController = (Base = class {}) =>
             this.style.top = `${top}px`;
             this.style.left = `${left}px`;
             this.style.width = `${width}px`;
+            this.style.height = 'auto';
             break;
 
           case 'bottom':
             this.style.top = `${bottom}px`;
             this.style.left = `${left}px`;
             this.style.width = `${width}px`;
+            this.style.height = 'auto';
             break;
 
           case 'left':
             this.style.top = `${top}px`;
             this.style.left = `${left}px`;
+            this.style.width = 'auto';
             this.style.height = `${height}px`;
             break;
 
           default:
             this.style.top = `${top}px`;
             this.style.left = `${right}px`;
+            this.style.width = 'auto';
             this.style.height = `${height}px`;
             break;
         }
@@ -115,6 +118,8 @@ export const TooltipController = (Base = class {}) =>
         this.style.zIndex = '99999';
 
         window.requestAnimationFrame(this.updateTooltipPosition);
+      } else {
+        this.removeAttribute('style');
       }
     }
 

--- a/packages/emd-basic-tooltip/src/component/TooltipController.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipController.js
@@ -13,8 +13,35 @@ export const TooltipController = (Base = class {}) =>
         text: {
           type: String,
           reflect: true
+        },
+        for: {
+          type: String,
+          reflect: true
         }
       };
+    }
+
+    get for () {
+      return this._for;
+    }
+
+    set for (value) {
+      const oldValue = this._for;
+      this._for = value;
+
+      if (this.target) {
+        console.log(this.target);
+      } else {
+        console.log('removed target');
+      }
+
+      this.requestUpdate('for', oldValue);
+    }
+
+    get target () {
+      return this.for && this.parentNode && this.parentNode.children
+        ? Array.from(this.parentNode.children).find(el => el.id === this.for)
+        : undefined;
     }
 
     render () {

--- a/packages/emd-basic-tooltip/src/component/TooltipController.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipController.js
@@ -2,6 +2,7 @@ export const TooltipController = (Base = class {}) =>
   class extends Base {
     constructor () {
       super();
+      this.updateTooltipPosition = this.updateTooltipPosition.bind(this);
       this.handleMouseOver = this.handleMouseOver.bind(this);
       this.handleMouseOut = this.handleMouseOut.bind(this);
     }
@@ -49,10 +50,6 @@ export const TooltipController = (Base = class {}) =>
     }
 
     unbindTooltipAndTarget () {
-      if (this._interval) {
-        window.cancelAnimationFrame(this._interval);
-      }
-
       this.removeAttribute('style');
 
       if (this.target) {
@@ -65,51 +62,56 @@ export const TooltipController = (Base = class {}) =>
       this.unbindTooltipAndTarget();
 
       if (this.target) {
-        this._interval = window.requestAnimationFrame(() => {
-          const {
-            top,
-            bottom,
-            left,
-            right,
-            width,
-            height
-          } = this.target.getBoundingClientRect();
-
-          const position = this.position || 'right';
-
-          switch (position) {
-            case 'top':
-              this.style.top = `${top}px`;
-              this.style.left = `${left}px`;
-              this.style.width = `${width}px`;
-              break;
-
-            case 'bottom':
-              this.style.top = `${bottom}px`;
-              this.style.left = `${left}px`;
-              this.style.width = `${width}px`;
-              break;
-
-            case 'left':
-              this.style.top = `${top}px`;
-              this.style.left = `${left}px`;
-              this.style.height = `${height}px`;
-              break;
-
-            case 'right':
-              this.style.top = `${top}px`;
-              this.style.left = `${right}px`;
-              this.style.height = `${height}px`;
-              break;
-          }
-
-          this.style.position = 'fixed';
-          this.style.margin = 'auto';
-          this.style.border = '1px solid #909';
-        });
-
         this.target.addEventListener('mouseover', this.handleMouseOver);
         this.target.addEventListener('mouseout', this.handleMouseOver);
+        window.requestAnimationFrame(this.updateTooltipPosition);
+      }
+    }
+
+    updateTooltipPosition () {
+      const {
+        top,
+        bottom,
+        left,
+        right,
+        width,
+        height
+      } = this.target.getBoundingClientRect();
+
+      const position = this.position || 'right';
+
+      switch (position) {
+        case 'top':
+          this.style.top = `${top}px`;
+          this.style.left = `${left}px`;
+          this.style.width = `${width}px`;
+          break;
+
+        case 'bottom':
+          this.style.top = `${bottom}px`;
+          this.style.left = `${left}px`;
+          this.style.width = `${width}px`;
+          break;
+
+        case 'left':
+          this.style.top = `${top}px`;
+          this.style.left = `${left}px`;
+          this.style.height = `${height}px`;
+          break;
+
+        case 'right':
+          this.style.top = `${top}px`;
+          this.style.left = `${right}px`;
+          this.style.height = `${height}px`;
+          break;
+      }
+
+      this.style.position = 'fixed';
+      this.style.margin = 'auto';
+      this.style.border = '1px solid #909';
+
+      if (this.target) {
+        window.requestAnimationFrame(this.updateTooltipPosition);
       }
     }
 

--- a/packages/emd-basic-tooltip/src/component/TooltipController.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipController.js
@@ -112,6 +112,7 @@ export const TooltipController = (Base = class {}) =>
 
         this.style.position = 'fixed';
         this.style.margin = 'auto';
+        this.style.zIndex = '99999';
 
         window.requestAnimationFrame(this.updateTooltipPosition);
       }

--- a/packages/emd-basic-tooltip/src/component/TooltipController.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipController.js
@@ -24,6 +24,10 @@ export const TooltipController = (Base = class {}) =>
         for: {
           type: String,
           reflect: true
+        },
+        targetActive: {
+          type: Boolean,
+          reflect: false
         }
       };
     }
@@ -63,64 +67,62 @@ export const TooltipController = (Base = class {}) =>
 
       if (this.target) {
         this.target.addEventListener('mouseover', this.handleMouseOver);
-        this.target.addEventListener('mouseout', this.handleMouseOver);
-        window.requestAnimationFrame(this.updateTooltipPosition);
+        this.target.addEventListener('mouseout', this.handleMouseOut);
       }
+
+      this.updateTooltipPosition();
     }
 
     updateTooltipPosition () {
-      const {
-        top,
-        bottom,
-        left,
-        right,
-        width,
-        height
-      } = this.target.getBoundingClientRect();
-
-      const position = this.position || 'right';
-
-      switch (position) {
-        case 'top':
-          this.style.top = `${top}px`;
-          this.style.left = `${left}px`;
-          this.style.width = `${width}px`;
-          break;
-
-        case 'bottom':
-          this.style.top = `${bottom}px`;
-          this.style.left = `${left}px`;
-          this.style.width = `${width}px`;
-          break;
-
-        case 'left':
-          this.style.top = `${top}px`;
-          this.style.left = `${left}px`;
-          this.style.height = `${height}px`;
-          break;
-
-        case 'right':
-          this.style.top = `${top}px`;
-          this.style.left = `${right}px`;
-          this.style.height = `${height}px`;
-          break;
-      }
-
-      this.style.position = 'fixed';
-      this.style.margin = 'auto';
-      this.style.border = '1px solid #909';
-
       if (this.target) {
+        const {
+          top,
+          bottom,
+          left,
+          right,
+          width,
+          height
+        } = this.target.getBoundingClientRect();
+
+        switch (this.position) {
+          case 'top':
+            this.style.top = `${top}px`;
+            this.style.left = `${left}px`;
+            this.style.width = `${width}px`;
+            break;
+
+          case 'bottom':
+            this.style.top = `${bottom}px`;
+            this.style.left = `${left}px`;
+            this.style.width = `${width}px`;
+            break;
+
+          case 'left':
+            this.style.top = `${top}px`;
+            this.style.left = `${left}px`;
+            this.style.height = `${height}px`;
+            break;
+
+          default:
+            this.style.top = `${top}px`;
+            this.style.left = `${right}px`;
+            this.style.height = `${height}px`;
+            break;
+        }
+
+        this.style.position = 'fixed';
+        this.style.margin = 'auto';
+
         window.requestAnimationFrame(this.updateTooltipPosition);
       }
     }
 
-    handleMouseOver (evt) {
-      console.log(evt);
+    handleMouseOver () {
+      this.targetActive = true;
     }
 
-    handleMouseOut (evt) {
-      console.log(evt);
+    handleMouseOut () {
+      this.targetActive = false;
     }
 
     render () {

--- a/packages/emd-basic-tooltip/src/component/TooltipController.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipController.js
@@ -41,14 +41,7 @@ export const TooltipController = (Base = class {}) =>
       super.attributeChangedCallback(attrName, pastValue, nextValue);
 
       if (attrName === 'for') {
-        this.removeTargetListeners();
-
-        this.target = this.parentNode && this.parentNode.children
-          ? Array.from(this.parentNode.children).find(el => el.id === nextValue)
-          : undefined;
-
-        this.addTargetListeners();
-        this.updateTooltipPosition();
+        this.bindToTarget(nextValue);
       }
 
       if (attrName === 'delay') {
@@ -58,6 +51,8 @@ export const TooltipController = (Base = class {}) =>
 
     connectedCallback () {
       super.connectedCallback();
+      this.bindToTarget(this.for);
+
       setTimeout(() => {
         this.isReady = true;
       }, 100);
@@ -66,6 +61,17 @@ export const TooltipController = (Base = class {}) =>
     disconnectedCallback () {
       super.disconnectedCallback();
       this.removeTargetListeners();
+    }
+
+    bindToTarget (target) {
+      this.removeTargetListeners();
+
+      this.target = this.parentNode && this.parentNode.children
+        ? Array.from(this.parentNode.children).find(el => el.id === target)
+        : undefined;
+
+      this.addTargetListeners();
+      this.updateTooltipPosition();
     }
 
     removeTargetListeners () {

--- a/packages/emd-basic-tooltip/src/component/TooltipController.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipController.js
@@ -28,6 +28,10 @@ export const TooltipController = (Base = class {}) =>
         targetActive: {
           type: Boolean,
           reflect: false
+        },
+        isReady: {
+          type: Boolean,
+          reflect: false
         }
       };
     }
@@ -49,6 +53,9 @@ export const TooltipController = (Base = class {}) =>
 
     connectedCallback () {
       super.connectedCallback();
+      setTimeout(() => {
+        this.isReady = true;
+      }, 100);
     }
 
     disconnectedCallback () {

--- a/packages/emd-basic-tooltip/src/component/TooltipController.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipController.js
@@ -9,15 +9,12 @@ export const TooltipController = (Base = class {}) =>
 
     static get properties () {
       return {
-        view: {
-          type: String,
-          reflect: true
-        },
         position: {
           type: String,
           reflect: true
         },
         text: {
+          /* legacy */
           type: String,
           reflect: true
         },

--- a/packages/emd-basic-tooltip/src/component/TooltipView.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipView.js
@@ -2,7 +2,8 @@ import { html } from '@stone-payments/lit-element';
 
 export const TooltipView = ({
   position = 'right',
-  text,
+  text, /* legacy */
+  shadow,
   for: forProp,
   target,
   targetActive,
@@ -24,6 +25,10 @@ export const TooltipView = ({
 
   tooltipTextClass += isReady
     ? ' emd-tooltip__text_ready'
+    : '';
+
+  tooltipTextClass += shadow
+    ? ' emd-tooltip__text_shadow'
     : '';
 
   return html`

--- a/packages/emd-basic-tooltip/src/component/TooltipView.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipView.js
@@ -3,6 +3,7 @@ import { html } from '@stone-payments/lit-element';
 export const TooltipView = ({
   position = 'right',
   text,
+  for: forProp,
   target,
   targetActive,
   isReady
@@ -29,7 +30,7 @@ export const TooltipView = ({
     <style>
       @import url("emd-basic-tooltip/src/component/Tooltip.css")
     </style>
-    ${target ? html`
+    ${forProp ? html`
       <div class="${wrapperClass}">
         <span class="${tooltipTextClass}">
           <slot></slot>

--- a/packages/emd-basic-tooltip/src/component/TooltipView.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipView.js
@@ -1,8 +1,20 @@
 import { html } from '@stone-payments/lit-element';
 
-export const TooltipView = ({ position = 'right', text, target }) => {
+export const TooltipView = ({
+  position = 'right',
+  text,
+  target,
+  targetActive
+}) => {
   let wrapperClass = 'emd-tooltip__wrapper';
-  wrapperClass += target ? ' emd-tooltip__wrapper_targeted' : '';
+
+  wrapperClass += target
+    ? ' emd-tooltip__wrapper_targeted'
+    : ' emd-tooltip__wrapper_legacy';
+
+  wrapperClass += target && targetActive
+    ? ' emd-tooltip__wrapper_active'
+    : '';
 
   let tooltipTextClass = 'emd-tooltip__text';
   tooltipTextClass += ` emd-tooltip__text_position_${position}`;
@@ -12,6 +24,7 @@ export const TooltipView = ({ position = 'right', text, target }) => {
       @import url("emd-basic-tooltip/src/component/Tooltip.css")
     </style>
     <div class="${wrapperClass}">
+      ${targetActive}
       <slot></slot>
       <span class="${tooltipTextClass}">
         ${text}

--- a/packages/emd-basic-tooltip/src/component/TooltipView.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipView.js
@@ -4,7 +4,8 @@ export const TooltipView = ({
   position = 'right',
   text,
   target,
-  targetActive
+  targetActive,
+  isReady
 }) => {
   let wrapperClass = 'emd-tooltip__wrapper';
 
@@ -17,7 +18,12 @@ export const TooltipView = ({
     : '';
 
   let tooltipTextClass = 'emd-tooltip__text';
+
   tooltipTextClass += ` emd-tooltip__text_position_${position}`;
+
+  tooltipTextClass += isReady
+    ? ' emd-tooltip__text_ready'
+    : '';
 
   return html`
     <style>

--- a/packages/emd-basic-tooltip/src/component/TooltipView.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipView.js
@@ -23,11 +23,19 @@ export const TooltipView = ({
     <style>
       @import url("emd-basic-tooltip/src/component/Tooltip.css")
     </style>
-    <div class="${wrapperClass}">
-      <slot></slot>
-      <span class="${tooltipTextClass}">
-        ${text}
-      </span>
-    </div>
+    ${target ? html`
+      <div class="${wrapperClass}">
+        <span class="${tooltipTextClass}">
+          <slot></slot>
+        </span>
+      </div>
+    ` : html`
+      <div class="${wrapperClass}">
+        <slot></slot>
+        <span class="${tooltipTextClass}">
+          ${text}
+        </span>
+      </div>
+    `}
   `;
 };

--- a/packages/emd-basic-tooltip/src/component/TooltipView.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipView.js
@@ -24,7 +24,6 @@ export const TooltipView = ({
       @import url("emd-basic-tooltip/src/component/Tooltip.css")
     </style>
     <div class="${wrapperClass}">
-      ${targetActive}
       <slot></slot>
       <span class="${tooltipTextClass}">
         ${text}

--- a/packages/emd-basic-tooltip/src/component/TooltipView.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipView.js
@@ -1,13 +1,21 @@
 import { html } from '@stone-payments/lit-element';
 
-export const TooltipView = ({ position, text }) => html`
-  <style>
-    @import url("emd-basic-tooltip/src/component/Tooltip.css")
-  </style>
-  <div class="emd-tooltip__wrapper">
-    <slot></slot>
-    <span class="emd-tooltip__text emd-tooltip__text_position_${position || 'right'}">
-      ${text}
-    </span>
-  </div>
-`;
+export const TooltipView = ({ position = 'right', text, target }) => {
+  let wrapperClass = 'emd-tooltip__wrapper';
+  wrapperClass += target ? ' emd-tooltip__wrapper_targeted' : '';
+
+  let tooltipTextClass = 'emd-tooltip__text';
+  tooltipTextClass += ` emd-tooltip__text_position_${position}`;
+
+  return html`
+    <style>
+      @import url("emd-basic-tooltip/src/component/Tooltip.css")
+    </style>
+    <div class="${wrapperClass}">
+      <slot></slot>
+      <span class="${tooltipTextClass}">
+        ${text}
+      </span>
+    </div>
+  `;
+};


### PR DESCRIPTION
## Description

This PR makes a radical change in the way the Tooltip is used and how it is positioned on screen. Although it seems to not have changed, the component doesn't wrap the target anymore, which:

- Prevents a bug that would cause unwanted scrollbars to appear while the tooltip is visible;
- Allows the tooltip to have any complex markup inside it, instead of just a string.

Please note that, for compatibility reasons, the legacy mark-up still works if the tooltip doesn't receive a `for` property, but only the new mark-up is documented.

### Legacy mark-up

```html
<emd-tooltip text="Some tooltip information">
  <p>Target element</p>
</emd-tooltip>
```

### New mark-up

```html
<p id="target">Target element</p>

<emd-tooltip for="target">
  Some <em>tooltip</em> information.
  <img src="logo.png"/>
</emd-tooltip>
```

This PR also adds new CSS properties and HTML attributes to better control the Tooltip appearance.

### Screen shots

<img width="1364" alt="Captura de Tela 2020-03-23 às 11 52 57" src="https://user-images.githubusercontent.com/125764/77343537-99797680-6d10-11ea-890b-275ee33e1c7f.png">

<img width="1364" alt="Captura de Tela 2020-03-23 às 11 53 26" src="https://user-images.githubusercontent.com/125764/77343557-a007ee00-6d10-11ea-9483-9683b42d5f71.png">

## Run

```
npm i && npm start emd-basic-tooltip
```

## Storybook

```
npm i && npm run storybook
```

## Test

```
npm i && npm t
```