### PR TITLE
Fix — Add example with two buttons

### DIFF
--- a/packages/emd-basic-notification/public/index.html
+++ b/packages/emd-basic-notification/public/index.html
@@ -22,6 +22,14 @@
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   </emd-notification>
 
+  <emd-notification mode="success">
+    <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
+    <div slot="action">
+      <button>Stay</button>
+      <button>Go</button>
+    </div>
+  </emd-notification>
+
   <h1>Notification&thinsp;—&thinsp;Compact</h1>
   <emd-notification view="compact" mode="success">
     <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
@@ -34,6 +42,14 @@
 
   <emd-notification view="compact" mode="danger">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  </emd-notification>
+
+  <emd-notification view="compact" mode="success">
+    <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
+    <div slot="action">
+      <button>Stay</button>
+      <button>Go</button>
+    </div>
   </emd-notification>
 </body>
 </html>


### PR DESCRIPTION
Add example with two buttons just to test the CI.

<img width="915" alt="Captura de Tela 2020-07-02 às 12 16 01" src="https://user-images.githubusercontent.com/125764/86376795-e9e06880-bc5d-11ea-870e-aff8265ec8fe.png">
