### PR TITLE
Hotfix — Slots with multiple children

### DIFF
--- a/packages/emd-basic-notification/public/index.css
+++ b/packages/emd-basic-notification/public/index.css
@@ -16,14 +16,6 @@ body {
   grid-gap: 30px;
 }
 
-.fake-component {
-  width: 100%;
-  height: 200px;
-  background: repeating-linear-gradient(
-    45deg,
-    rgba(45, 56, 68, 0.075),
-    rgba(45, 56, 68, 0.075) 10px,
-    rgba(45, 56, 68, 0.15) 10px,
-    rgba(45, 56, 68, 0.15) 20px
-  );
+button + button {
+  margin-left: 0.5em;
 }

--- a/packages/emd-basic-notification/public/index.html
+++ b/packages/emd-basic-notification/public/index.html
@@ -24,10 +24,8 @@
 
   <emd-notification mode="success">
     <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
-    <div slot="action">
-      <button>Stay</button>
-      <button>Go</button>
-    </div>
+    <button slot="action">Stay</button>
+    <button slot="action">Go</button>
   </emd-notification>
 
   <h1>Notification&thinsp;—&thinsp;Compact</h1>
@@ -46,10 +44,8 @@
 
   <emd-notification view="compact" mode="success">
     <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
-    <div slot="action">
-      <button>Stay</button>
-      <button>Go</button>
-    </div>
+    <button slot="action">Stay</button>
+    <button slot="action">Go</button>
   </emd-notification>
 </body>
 </html>

--- a/packages/emd-basic-notification/src/component/Notification.css
+++ b/packages/emd-basic-notification/src/component/Notification.css
@@ -50,12 +50,16 @@
   width: 100%;
 }
 
-.emd-notification__wrapper slot[name="action"]::slotted(*) {
+.emd-notification__wrapper:not(.has-action) .action-wrapper {
+  display: none;
+}
+
+.emd-notification__wrapper .action-wrapper {
   flex-shrink: 0;
   margin-left: 24px;
 }
 
-.emd-notification__wrapper.is-compact slot[name="action"]::slotted(*) {
+.emd-notification__wrapper.is-compact .action-wrapper {
   margin-left: 0;
   margin-top: 1em;
 }

--- a/packages/emd-basic-notification/src/component/NotificationController.js
+++ b/packages/emd-basic-notification/src/component/NotificationController.js
@@ -9,8 +9,23 @@ export const NotificationController = (Base = class {}) =>
         mode: {
           type: String,
           reflect: true
+        },
+        hasAction: {
+          type: Boolean,
+          reflect: false
         }
       };
+    }
+
+    actionSlot () {
+      return this.renderRoot
+        ? this.renderRoot.querySelector('slot[name=action]')
+        : undefined;
+    }
+
+    childrenUpdatedCallback () {
+      const filledSlots = Array.from(this.children).map(item => item.slot);
+      this.hasAction = filledSlots.includes('action');
     }
 
     render () {

--- a/packages/emd-basic-notification/src/component/NotificationController.js
+++ b/packages/emd-basic-notification/src/component/NotificationController.js
@@ -17,12 +17,6 @@ export const NotificationController = (Base = class {}) =>
       };
     }
 
-    actionSlot () {
-      return this.renderRoot
-        ? this.renderRoot.querySelector('slot[name=action]')
-        : undefined;
-    }
-
     childrenUpdatedCallback () {
       const filledSlots = Array.from(this.children).map(item => item.slot);
       this.hasAction = filledSlots.includes('action');

--- a/packages/emd-basic-notification/src/component/NotificationView.js
+++ b/packages/emd-basic-notification/src/component/NotificationView.js
@@ -14,11 +14,13 @@ const svgMap = {
 
 export const NotificationView = ({
   view,
-  mode = 'alert'
+  mode = 'alert',
+  hasAction
 }) => {
   let wrapperClass = 'emd-notification__wrapper';
   wrapperClass += view ? ` is-${view}` : '';
   wrapperClass += mode ? ` is-${mode}` : '';
+  wrapperClass += hasAction ? ' has-action' : '';
 
   return html`
     <style>
@@ -30,8 +32,8 @@ export const NotificationView = ({
           ${svgMap[mode]}
         </div>
         <div class="content">
-          <slot></slot>
-          <slot name="action"></slot>
+          <div class="text-wrapper"><slot></slot></div>
+          <div class="action-wrapper"><slot name="action"></slot></div>
         </div>
       </div>
     </div>

--- a/packages/emd-basic-notification/src/core.js
+++ b/packages/emd-basic-notification/src/core.js
@@ -1,5 +1,5 @@
 import { compose } from '@stone-payments/emd-helpers';
-import { withComponent } from '@stone-payments/emd-hocs';
+import { withComponent, withObservedChildren } from '@stone-payments/emd-hocs';
 import { LitElement } from '@stone-payments/lit-element';
 
 import { NotificationController } from './component/NotificationController.js';
@@ -7,6 +7,7 @@ import { NotificationView } from './component/NotificationView.js';
 
 const Notification = compose(
   NotificationController,
+  withObservedChildren,
   withComponent
 )(LitElement);
 


### PR DESCRIPTION
## Description

Fixes a layout problem when multiple children were added to any slot.

### Before

<img width="617" alt="Captura de Tela 2020-07-02 às 14 41 45" src="https://user-images.githubusercontent.com/125764/86392966-b0662800-bc72-11ea-980f-b1ad869e730c.png">

### After

<img width="617" alt="Captura de Tela 2020-07-02 às 14 42 43" src="https://user-images.githubusercontent.com/125764/86392977-b52adc00-bc72-11ea-80d9-52057b89744e.png">

## Test

```
npm i && npm t
```

## Run locally

```
npm i && npm start emd-basic-notification
```
