### PR TITLE
Feat — Slideshow gap and events

### DIFF
--- a/packages/emd-basic-slideshow/README.md
+++ b/packages/emd-basic-slideshow/README.md
@@ -41,3 +41,31 @@ Controlls the gap between slides.
 #### Default
 
 The slide's container. Each component's child element becomes a slide.
+
+## Events
+
+#### `slidechange` (alias `slidechangestart`)
+
+Dispatched when the current slide changes but before the animation begins.
+
+- Detail:
+
+```javascript
+{
+  previous: 2,
+  current: 3
+}
+```
+
+#### `slidechangeend`
+
+Dispatched after the current slide changes and the animation ends.
+
+- Detail:
+
+```javascript
+{
+  previous: 2,
+  current: 3
+}
+```

--- a/packages/emd-basic-slideshow/README.md
+++ b/packages/emd-basic-slideshow/README.md
@@ -27,3 +27,17 @@ The delay of the transition in milliseconds. Defaults to `300` if unset.
 
 - Type: Number
 - Attribute and property
+
+## CSS Properties
+
+#### `--emd-slideshow-gap`
+
+Controlls the gap between slides.
+
+- Default: `0px`
+
+## Slots
+
+#### Default
+
+The slide's container. Each component's child element becomes a slide.

--- a/packages/emd-basic-slideshow/src/component/Slideshow.css
+++ b/packages/emd-basic-slideshow/src/component/Slideshow.css
@@ -32,11 +32,11 @@
 }
 
 ::slotted([before]) {
-  transform: translate(-100%);
+  transform: translate(calc(-100% - var(--emd-slideshow-gap, 0px)));
 }
 
 ::slotted([after]) {
-  transform: translate(100%);
+  transform: translate(calc(var(--emd-slideshow-gap, 0px) + 100%));
 }
 
 /* for Edge compatibility */

--- a/packages/emd-basic-slideshow/src/component/Slideshow.stories.js
+++ b/packages/emd-basic-slideshow/src/component/Slideshow.stories.js
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/vue';
 import { withKnobs, number, text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import readMe from '../../README.md';
 import '../index.js';
 
@@ -15,6 +16,10 @@ const delayOptions = {
   min: 0,
   max: 1200,
   step: 300
+};
+
+const logEvent = ({ type, detail }) => {
+  action(type)(detail);
 };
 
 function getCodeSample () {
@@ -43,6 +48,9 @@ function getCodeSample () {
 storiesOf('Slideshow', module)
   .addDecorator(withKnobs)
   .add('Default', () => ({
+    methods: {
+      logEvent
+    },
     props: {
       current: {
         default: number('Current slide', 1, slideOptions)
@@ -61,6 +69,9 @@ storiesOf('Slideshow', module)
             :current="current"
             :delay="delay"
             :style="{ '--emd-slideshow-gap': gap }"
+            @slidechange="logEvent"
+            @slidechangestart="logEvent"
+            @slidechangeend="logEvent"
           >
             <div style="background: #f4a589; text-align: center; padding: 1em 0;">One</div>
             <div style="background: #e4b599; text-align: center; padding: 1em 0;">Two</div>

--- a/packages/emd-basic-slideshow/src/component/Slideshow.stories.js
+++ b/packages/emd-basic-slideshow/src/component/Slideshow.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/vue';
-import { withKnobs, number } from '@storybook/addon-knobs';
+import { withKnobs, number, text } from '@storybook/addon-knobs';
 import readMe from '../../README.md';
 import '../index.js';
 
@@ -22,7 +22,17 @@ function getCodeSample () {
   attrs += this.current ? ` current="${this.current}"` : '';
   attrs += this.delay ? ` delay="${this.delay}"` : '';
 
-  return `<emd-slideshow${attrs}>
+  const hasCustomStyle = this.gap;
+
+  const styles = hasCustomStyle ? `<style>
+  emd-slideshow {
+    --emd-slideshow-gap: ${this.gap};
+  }
+</style>
+
+` : '';
+
+  return `${styles}<emd-slideshow${attrs}>
   <div>One</div>
   <div>Two</div>
   <div>Three</div>
@@ -39,6 +49,9 @@ storiesOf('Slideshow', module)
       },
       delay: {
         default: number('Delay (ms)', 300, delayOptions)
+      },
+      gap: {
+        default: text('Gap', '0px')
       }
     },
     template: `
@@ -47,6 +60,7 @@ storiesOf('Slideshow', module)
           <emd-slideshow
             :current="current"
             :delay="delay"
+            :style="{ '--emd-slideshow-gap': gap }"
           >
             <div style="background: #f4a589; text-align: center; padding: 1em 0;">One</div>
             <div style="background: #e4b599; text-align: center; padding: 1em 0;">Two</div>

--- a/packages/emd-basic-slideshow/src/component/SlideshowController.js
+++ b/packages/emd-basic-slideshow/src/component/SlideshowController.js
@@ -49,13 +49,6 @@ export const SlideshowController = (Base = class {}) =>
         : Math.max(0, rounded);
     }
 
-    attributeChangedCallback (attrName, pastValue, nextValue) {
-      super.attributeChangedCallback(attrName, pastValue, nextValue);
-      if (attrName === 'delay') {
-        this.style.setProperty('--emd-slideshow-delay', `${nextValue}ms`);
-      }
-    }
-
     childrenUpdatedCallback () {
       this.slideCount = this.children.length;
 

--- a/packages/emd-basic-slideshow/src/component/SlideshowController.js
+++ b/packages/emd-basic-slideshow/src/component/SlideshowController.js
@@ -14,25 +14,24 @@ export const SlideshowController = (Base = class {}) =>
     }
 
     get current () {
-      return this._current;
+      return this._current == null
+        ? Number(this.slideCount != null && this.slideCount > 0)
+        : this._current;
     }
 
     set current (value) {
-      const oldValue = this._current;
-      const nextValue = this._parseCurrent(value) || oldValue;
+      const oldValue = this.current;
+      const parsedValue = this._parseUserDefinedCurrent(value);
+      const nextValue = parsedValue != null ? parsedValue : oldValue;
 
-      if (nextValue != null) {
-        this._current = nextValue;
-        this.setAttribute('current', nextValue);
-      } else {
-        this.removeAttribute('current');
-      }
+      this._current = nextValue;
 
+      this.setAttribute('current', nextValue);
       this.requestUpdate('current', oldValue);
       this._updateSlides();
     }
 
-    _parseCurrent (current) {
+    _parseUserDefinedCurrent (current) {
       const parsed = Number(current);
 
       if (Number.isNaN(parsed)) {
@@ -63,8 +62,6 @@ export const SlideshowController = (Base = class {}) =>
     }
 
     _updateSlides () {
-      const parsedCurrent = this.current || 1;
-
       Array.from(this.children).forEach((slide, index) => {
         const slideNumber = index + 1;
 
@@ -72,9 +69,9 @@ export const SlideshowController = (Base = class {}) =>
         slide.removeAttribute('current');
         slide.removeAttribute('after');
 
-        if (slideNumber < parsedCurrent) {
+        if (slideNumber < this.current) {
           slide.setAttribute('before', '');
-        } else if (slideNumber > parsedCurrent) {
+        } else if (slideNumber > this.current) {
           slide.setAttribute('after', '');
         } else {
           slide.setAttribute('current', '');

--- a/packages/emd-basic-slideshow/src/component/SlideshowController.js
+++ b/packages/emd-basic-slideshow/src/component/SlideshowController.js
@@ -58,6 +58,11 @@ export const SlideshowController = (Base = class {}) =>
 
     childrenUpdatedCallback () {
       this.slideCount = this.children.length;
+
+      // trigger `current` accessors when the number of slides change
+      const nextCurrent = this.current;
+      this.current = nextCurrent;
+
       this._updateSlides();
     }
 

--- a/packages/emd-basic-slideshow/src/component/SlideshowController.spec.js
+++ b/packages/emd-basic-slideshow/src/component/SlideshowController.spec.js
@@ -130,26 +130,6 @@ describe('SlideshowController', () => {
     });
   });
 
-  describe('#attributeChangedCallback()', () => {
-    it('Should call super.attributeChangedCallback', () => {
-      element.attributeChangedCallback('attr', 0, 3000);
-
-      expect(HTMLElement.prototype.attributeChangedCallback)
-        .to.have.been.calledOnceWith('attr', 0, 3000);
-    });
-
-    it('Should set the delay CSS property', () => {
-      element.style = {
-        setProperty: sinon.spy()
-      };
-
-      element.attributeChangedCallback('delay', 0, 3000);
-
-      expect(element.style.setProperty)
-        .to.have.been.calledOnceWith('--emd-slideshow-delay', '3000ms');
-    });
-  });
-
   describe('#childrenUpdatedCallback()', () => {
     let setSpy;
 

--- a/packages/emd-basic-slideshow/src/component/SlideshowController.spec.js
+++ b/packages/emd-basic-slideshow/src/component/SlideshowController.spec.js
@@ -155,6 +155,8 @@ describe('SlideshowController', () => {
   });
 
   describe('#childrenUpdatedCallback()', () => {
+    let setSpy;
+
     beforeEach(() => {
       element.children = [
         new HTMLElement(),
@@ -163,11 +165,22 @@ describe('SlideshowController', () => {
       ];
 
       element._updateSlides = sinon.spy();
+      setSpy = sinon.spy();
+
+      Object.defineProperty(element, 'current', {
+        get () { return this._current; },
+        set (value) { this._current = value; setSpy(); }
+      });
     });
 
     it('Should update slideCount', () => {
       element.childrenUpdatedCallback();
       expect(element.slideCount).to.equal(3);
+    });
+
+    it('Should update current according to the new number of slides', () => {
+      element.childrenUpdatedCallback();
+      expect(setSpy).to.have.been.calledOnce;
     });
 
     it('Should call _updateSlides', () => {

--- a/packages/emd-basic-slideshow/src/component/SlideshowController.spec.js
+++ b/packages/emd-basic-slideshow/src/component/SlideshowController.spec.js
@@ -40,7 +40,6 @@ describe('SlideshowController', () => {
     beforeEach(() => {
       element.requestUpdate = sinon.spy();
       element._updateSlides = sinon.spy();
-      element._parseUserDefinedCurrent = sinon.stub().returnsArg(0);
     });
 
     it('Should return zero when unset and there are no slides', () => {
@@ -62,16 +61,13 @@ describe('SlideshowController', () => {
     });
 
     it('Should parse the given value before setting it', () => {
+      element._parseUserDefinedCurrent = sinon.stub().returnsArg(0);
       element.current = 3;
       expect(element._parseUserDefinedCurrent).to.have.been.calledWith(3);
     });
 
     it('Should return the previous value if ' +
-      'parsing returns undefined', () => {
-      element._parseUserDefinedCurrent = sinon.stub();
-      element._parseUserDefinedCurrent.withArgs('bogus').returns(undefined);
-      element._parseUserDefinedCurrent.withArgs(3).returnsArg(0);
-
+      'received a bogus value', () => {
       element.current = 3;
       element.current = 'bogus';
 
@@ -93,7 +89,7 @@ describe('SlideshowController', () => {
       expect(element._updateSlides).to.have.been.calledOnce;
     });
 
-    it('Should correctly set current to zero after it being one', () => {
+    it('Should correctly set to zero after it being one', () => {
       element.current = 1;
       element.current = 0;
       expect(element.current).to.equal(0);

--- a/packages/emd-basic-slideshow/src/component/SlideshowView.js
+++ b/packages/emd-basic-slideshow/src/component/SlideshowView.js
@@ -1,10 +1,10 @@
 import { html } from '@stone-payments/lit-element';
 
-export const SlideshowView = () => html`
+export const SlideshowView = ({ delay = 300 }) => html`
   <style>
     @import url("emd-basic-slideshow/src/component/Slideshow.css")
   </style>
-  <div class="emd-slideshow__wrapper">
+  <div class="emd-slideshow__wrapper" style="--emd-slideshow-delay: ${delay}ms">
     <div class="container">
       <slot></slot>
     </div>

--- a/packages/emd-basic-tooltip/src/component/TooltipController.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipController.js
@@ -47,10 +47,6 @@ export const TooltipController = (Base = class {}) =>
       if (attrName === 'for') {
         this.bindToTarget(nextValue);
       }
-
-      if (attrName === 'delay') {
-        this.style.setProperty('--emd-tooltip-delay', `${nextValue}ms`);
-      }
     }
 
     connectedCallback () {

--- a/packages/emd-basic-tooltip/src/component/TooltipView.js
+++ b/packages/emd-basic-tooltip/src/component/TooltipView.js
@@ -7,7 +7,8 @@ export const TooltipView = ({
   for: forProp,
   target,
   targetActive,
-  isReady
+  isReady,
+  delay = 0
 }) => {
   let wrapperClass = 'emd-tooltip__wrapper';
 
@@ -36,7 +37,7 @@ export const TooltipView = ({
       @import url("emd-basic-tooltip/src/component/Tooltip.css")
     </style>
     ${forProp ? html`
-      <div class="${wrapperClass}">
+      <div class="${wrapperClass}" style="--emd-tooltip-delay: ${delay}ms">
         <span class="${tooltipTextClass}">
           <slot></slot>
         </span>


### PR DESCRIPTION
## Description

- Implements `--emd-slideshow-gap` CSS property to control the gap between slides
- Dispatches `slidechange` (alias: `slidechangestart`) when the current slide changes, just before the animation begins.
- Dispatches `slidechangeend` after the current slide changes and the animation ends.

The PR also moves the responsibility of changing the `delay` property from the Controller to the View on both Tooltip and Slideshow components.

## Test

```
npm i && npm t
```

## Run locally

```
npm i && npm start emd-basic-slideshow
```

## Storybook

```
npm i && npm run storybook
```
