### PR TITLE
Fix — Revert incorrect Semantic Release attempt

### DIFF
--- a/packages/emd-basic-brand-icon/CHANGELOG.md
+++ b/packages/emd-basic-brand-icon/CHANGELOG.md
@@ -1,10 +1,3 @@
-# @stone-payments/emd-basic-brand-icon-v1.0.0 (2020-08-03)
-
-
-### Features
-
-* Move package to master ([8dbabdd](https://github.com/stone-payments/emerald-web-framework/commit/8dbabdd551c0b143e67837b9ed34e7dbc23e6370))
-
 # [@stone-payments/emd-basic-brand-icon-v1.8.0](https://github.com/stone-payments/emerald-web-framework/compare/@stone-payments/emd-basic-brand-icon-v1.7.0...@stone-payments/emd-basic-brand-icon-v1.8.0) (2020-05-14)
 
 

--- a/packages/emd-basic-brand-icon/package-lock.json
+++ b/packages/emd-basic-brand-icon/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stone-payments/emd-basic-brand-icon",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/emd-basic-brand-icon/package.json
+++ b/packages/emd-basic-brand-icon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stone-payments/emd-basic-brand-icon",
   "description": "emd-basic-brand-icon",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "module": "src/index.js",
   "main": "dist/cjs/es5/index.js",
   "jsnext:main": "dist/es/es6/index.js",


### PR DESCRIPTION
This reverts commit cdb7527670c2964d39b20906ef43f5d359885de9.

Semantic Release tried to change a component version from 1.8.0 to 1.0.0. This reverts the commit