### PR TITLE
fix: Substitute deprecated currentView.apply for currentView.use

### DIFF
--- a/packages/emd-basic-brand-icon/src/component/BrandIconController.js
+++ b/packages/emd-basic-brand-icon/src/component/BrandIconController.js
@@ -65,6 +65,6 @@ export const BrandIconController = (Base = class {}) => class extends Base {
   }
 
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-brand-icon/src/component/BrandIconController.spec.js
+++ b/packages/emd-basic-brand-icon/src/component/BrandIconController.spec.js
@@ -191,10 +191,10 @@ describe('BrandIconController', () => {
   });
 
   describe('#render()', () => {
-    it('Should call currentView.apply', () => {
-      element.currentView = { apply: sinon.spy() };
+    it('Should call currentView.use', () => {
+      element.currentView = { use: sinon.spy() };
       element.render();
-      expect(element.currentView.apply).to.have.been.calledOnceWith(element);
+      expect(element.currentView.use).to.have.been.calledOnceWith(element);
     });
   });
 });

--- a/packages/emd-basic-bullet/src/component/BulletController.js
+++ b/packages/emd-basic-bullet/src/component/BulletController.js
@@ -1,6 +1,6 @@
 export const BulletController = (Base = class {}) =>
   class extends Base {
     render () {
-      return this.currentView.apply(this);
+      return this.currentView.use(this);
     }
   };

--- a/packages/emd-basic-card/src/component/CardController.js
+++ b/packages/emd-basic-card/src/component/CardController.js
@@ -60,6 +60,6 @@ export const CardController = (Base = class {}) => class extends Base {
   }
 
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-date/src/component/DateController.js
+++ b/packages/emd-basic-date/src/component/DateController.js
@@ -28,6 +28,6 @@ export const DateController = (Base = class {}) => class extends Base {
   }
 
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-drawer/src/component/DrawerController.js
+++ b/packages/emd-basic-drawer/src/component/DrawerController.js
@@ -111,6 +111,6 @@ export const DrawerController = (Base = class {}) => class extends Base {
   }
 
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-feature/src/component/FeatureController.js
+++ b/packages/emd-basic-feature/src/component/FeatureController.js
@@ -10,6 +10,6 @@ export const FeatureController = (Base = class {}) =>
     }
 
     render () {
-      return this.currentView.apply(this);
+      return this.currentView.use(this);
     }
   };

--- a/packages/emd-basic-field-message/src/component/FieldMessageController.js
+++ b/packages/emd-basic-field-message/src/component/FieldMessageController.js
@@ -13,6 +13,6 @@ export const FieldMessageController = (Base = class {}) => class extends Base {
   }
 
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-field-wrapper/src/component/FieldWrapperController.js
+++ b/packages/emd-basic-field-wrapper/src/component/FieldWrapperController.js
@@ -59,6 +59,6 @@ export const FieldWrapperController = (Base = class {}) =>
     }
 
     render () {
-      return this.currentView.apply(this);
+      return this.currentView.use(this);
     }
   };

--- a/packages/emd-basic-field/src/component/FieldController.js
+++ b/packages/emd-basic-field/src/component/FieldController.js
@@ -64,6 +64,6 @@ export const FieldController = (Base = class {}) => class extends Base {
   }
 
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-form/src/component/FormController.js
+++ b/packages/emd-basic-form/src/component/FormController.js
@@ -1,5 +1,5 @@
 export const FormController = (Base = class {}) => class extends Base {
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-icon/src/component/IconController.js
+++ b/packages/emd-basic-icon/src/component/IconController.js
@@ -18,6 +18,6 @@ export const IconController = (Base = class {}) => class extends Base {
   }
 
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-loader/src/component/LoaderController.js
+++ b/packages/emd-basic-loader/src/component/LoaderController.js
@@ -9,6 +9,6 @@ export const LoaderController = (Base = class {}) => class extends Base {
   }
 
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-loan-success-dialog/src/component/LoanSuccessDialogController.js
+++ b/packages/emd-basic-loan-success-dialog/src/component/LoanSuccessDialogController.js
@@ -24,6 +24,6 @@ export const LoanSuccessDialogController = (Base = class {}) =>
     }
 
     render () {
-      return this.currentView.apply(this);
+      return this.currentView.use(this);
     }
   };

--- a/packages/emd-basic-login/src/component/LoginController.js
+++ b/packages/emd-basic-login/src/component/LoginController.js
@@ -158,6 +158,6 @@ export const LoginController = (Base = class {}) =>
     }
 
     render () {
-      return this.currentView.apply(this);
+      return this.currentView.use(this);
     }
   };

--- a/packages/emd-basic-money-card/src/component/MoneyCardController.js
+++ b/packages/emd-basic-money-card/src/component/MoneyCardController.js
@@ -25,6 +25,6 @@ export const MoneyCardController = (Base = class {}) => class extends Base {
   }
 
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-money-promo/src/component/MoneyPromoController.js
+++ b/packages/emd-basic-money-promo/src/component/MoneyPromoController.js
@@ -22,6 +22,6 @@ export const MoneyPromoController = (Base = class {}) =>
     }
 
     render () {
-      return this.currentView.apply(this);
+      return this.currentView.use(this);
     }
   };

--- a/packages/emd-basic-money/src/component/MoneyController.js
+++ b/packages/emd-basic-money/src/component/MoneyController.js
@@ -56,6 +56,6 @@ export const MoneyController = (Base = class {}) => class extends Base {
   }
 
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-money/src/component/MoneyController.spec.js
+++ b/packages/emd-basic-money/src/component/MoneyController.spec.js
@@ -83,10 +83,10 @@ describe('MoneyController', () => {
   });
 
   describe('#render()', () => {
-    it('Should call currentView.apply', () => {
-      dummy.currentView = { apply: sinon.spy() };
+    it('Should call currentView.use', () => {
+      dummy.currentView = { use: sinon.spy() };
       dummy.render();
-      expect(dummy.currentView.apply).to.have.been.calledOnceWith(dummy);
+      expect(dummy.currentView.use).to.have.been.calledOnceWith(dummy);
     });
   });
 });

--- a/packages/emd-basic-pill/src/component/PillController.js
+++ b/packages/emd-basic-pill/src/component/PillController.js
@@ -1,5 +1,5 @@
 export const PillController = (Base = class {}) => class extends Base {
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-select/src/component/SelectController.js
+++ b/packages/emd-basic-select/src/component/SelectController.js
@@ -146,6 +146,6 @@ export const SelectController = (Base = class {}) => class extends Base {
   }
 
   render () {
-    return this.currentView.apply(this);
+    return this.currentView.use(this);
   }
 };

--- a/packages/emd-basic-simulator-result/src/component/SimulatorResultController.js
+++ b/packages/emd-basic-simulator-result/src/component/SimulatorResultController.js
@@ -22,6 +22,6 @@ export const SimulatorResultController = (Base = class {}) =>
     }
 
     render () {
-      return this.currentView.apply(this);
+      return this.currentView.use(this);
     }
   };

--- a/packages/emd-basic-state-wrapper/src/component/StateWrapperController.js
+++ b/packages/emd-basic-state-wrapper/src/component/StateWrapperController.js
@@ -136,6 +136,6 @@ export const StateWrapperController = (Base = class {}) =>
     }
 
     render () {
-      return this.currentView.apply(this);
+      return this.currentView.use(this);
     }
   };

--- a/packages/emd-basic-table/src/component/TableController.js
+++ b/packages/emd-basic-table/src/component/TableController.js
@@ -227,6 +227,6 @@ export const TableController = (Base = class {}) =>
     }
 
     render () {
-      return this.currentView.apply(this);
+      return this.currentView.use(this);
     }
   };

--- a/packages/emd-basic-table/src/component/TableController.spec.js
+++ b/packages/emd-basic-table/src/component/TableController.spec.js
@@ -405,10 +405,10 @@ describe('TableController', () => {
   });
 
   describe('#render()', () => {
-    it('Should call currentView.apply', () => {
-      dummy.currentView = { apply: sinon.spy() };
+    it('Should call currentView.use', () => {
+      dummy.currentView = { use: sinon.spy() };
       dummy.render();
-      expect(dummy.currentView.apply).to.have.been.calledOnceWith(dummy);
+      expect(dummy.currentView.use).to.have.been.calledOnceWith(dummy);
     });
   });
 });


### PR DESCRIPTION
## Description

The method `currentView.apply` was deprecated in favor of `currentView.use` a long time ago because `.apply()` is a method of `Function`.

This PR substitutes all `currentView.apply` used in components for `currentView.use`.

## Test

```
npm i && npm t
```

## Storybook

```
npm i && npm run storybook
```